### PR TITLE
6.2.0 seller removal

### DIFF
--- a/PagarmeApiSDK.Standard/Controllers/BaseController.cs
+++ b/PagarmeApiSDK.Standard/Controllers/BaseController.cs
@@ -148,7 +148,7 @@ namespace PagarmeApiSDK.Standard.Controllers
         /// </summary>
         private void UpdateUserAgent()
         {
-            internalUserAgent = "PagarmeCoreApi - DotNet 6.1.0-alpha.0";
+            internalUserAgent = "PagarmeCoreApi - DotNet 6.2.0";
         }
     }
 }

--- a/PagarmeApiSDK.Standard/Controllers/ChargesController.cs
+++ b/PagarmeApiSDK.Standard/Controllers/ChargesController.cs
@@ -179,6 +179,206 @@ namespace PagarmeApiSDK.Standard.Controllers
         }
 
         /// <summary>
+        /// Updates the card from a charge.
+        /// </summary>
+        /// <param name="chargeId">Required parameter: Charge id.</param>
+        /// <param name="request">Required parameter: Request for updating a charge's card.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <returns>Returns the Models.GetChargeResponse response from the API call.</returns>
+        public Models.GetChargeResponse UpdateChargeCard(
+                string chargeId,
+                Models.UpdateChargeCardRequest request,
+                string idempotencyKey = null)
+        {
+            Task<Models.GetChargeResponse> t = this.UpdateChargeCardAsync(chargeId, request, idempotencyKey);
+            ApiHelper.RunTaskSynchronously(t);
+            return t.Result;
+        }
+
+        /// <summary>
+        /// Updates the card from a charge.
+        /// </summary>
+        /// <param name="chargeId">Required parameter: Charge id.</param>
+        /// <param name="request">Required parameter: Request for updating a charge's card.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetChargeResponse response from the API call.</returns>
+        public async Task<Models.GetChargeResponse> UpdateChargeCardAsync(
+                string chargeId,
+                Models.UpdateChargeCardRequest request,
+                string idempotencyKey = null,
+                CancellationToken cancellationToken = default)
+        {
+            // the base uri for api requests.
+            string baseUri = this.Config.GetBaseUri();
+
+            // prepare query string for API call.
+            StringBuilder queryBuilder = new StringBuilder(baseUri);
+            queryBuilder.Append("/charges/{charge_id}/card");
+
+            // process optional template parameters.
+            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
+            {
+                { "charge_id", chargeId },
+            });
+
+            // append request with appropriate headers and parameters
+            var headers = new Dictionary<string, string>()
+            {
+                { "user-agent", this.UserAgent },
+                { "accept", "application/json" },
+                { "content-type", "application/json; charset=utf-8" },
+                { "idempotency-key", idempotencyKey },
+            };
+
+            // append body params.
+            var bodyText = ApiHelper.JsonSerialize(request);
+
+            // prepare the API call request to fetch the response.
+            HttpRequest httpRequest = this.GetClientInstance().PatchBody(queryBuilder.ToString(), headers, bodyText);
+
+            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
+
+            // invoke request and get response.
+            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+            HttpContext context = new HttpContext(httpRequest, response);
+
+            // handle errors defined at the API level.
+            this.ValidateResponse(response, context);
+
+            return ApiHelper.JsonDeserialize<Models.GetChargeResponse>(response.Body);
+        }
+
+        /// <summary>
+        /// GetChargesSummary EndPoint.
+        /// </summary>
+        /// <param name="status">Required parameter: Example: .</param>
+        /// <param name="createdSince">Optional parameter: Example: .</param>
+        /// <param name="createdUntil">Optional parameter: Example: .</param>
+        /// <returns>Returns the Models.GetChargesSummaryResponse response from the API call.</returns>
+        public Models.GetChargesSummaryResponse GetChargesSummary(
+                string status,
+                DateTime? createdSince = null,
+                DateTime? createdUntil = null)
+        {
+            Task<Models.GetChargesSummaryResponse> t = this.GetChargesSummaryAsync(status, createdSince, createdUntil);
+            ApiHelper.RunTaskSynchronously(t);
+            return t.Result;
+        }
+
+        /// <summary>
+        /// GetChargesSummary EndPoint.
+        /// </summary>
+        /// <param name="status">Required parameter: Example: .</param>
+        /// <param name="createdSince">Optional parameter: Example: .</param>
+        /// <param name="createdUntil">Optional parameter: Example: .</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetChargesSummaryResponse response from the API call.</returns>
+        public async Task<Models.GetChargesSummaryResponse> GetChargesSummaryAsync(
+                string status,
+                DateTime? createdSince = null,
+                DateTime? createdUntil = null,
+                CancellationToken cancellationToken = default)
+        {
+            // the base uri for api requests.
+            string baseUri = this.Config.GetBaseUri();
+
+            // prepare query string for API call.
+            StringBuilder queryBuilder = new StringBuilder(baseUri);
+            queryBuilder.Append("/charges/summary");
+
+            // prepare specfied query parameters.
+            var queryParams = new Dictionary<string, object>()
+            {
+                { "status", status },
+                { "created_since", createdSince.HasValue ? createdSince.Value.ToString("yyyy'-'MM'-'dd'T'HH':'mm':'ss.FFFFFFFK") : null },
+                { "created_until", createdUntil.HasValue ? createdUntil.Value.ToString("yyyy'-'MM'-'dd'T'HH':'mm':'ss.FFFFFFFK") : null },
+            };
+
+            // append request with appropriate headers and parameters
+            var headers = new Dictionary<string, string>()
+            {
+                { "user-agent", this.UserAgent },
+                { "accept", "application/json" },
+            };
+
+            // prepare the API call request to fetch the response.
+            HttpRequest httpRequest = this.GetClientInstance().Get(queryBuilder.ToString(), headers, queryParameters: queryParams);
+
+            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
+
+            // invoke request and get response.
+            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+            HttpContext context = new HttpContext(httpRequest, response);
+
+            // handle errors defined at the API level.
+            this.ValidateResponse(response, context);
+
+            return ApiHelper.JsonDeserialize<Models.GetChargesSummaryResponse>(response.Body);
+        }
+
+        /// <summary>
+        /// Creates a new charge.
+        /// </summary>
+        /// <param name="request">Required parameter: Request for creating a charge.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <returns>Returns the Models.GetChargeResponse response from the API call.</returns>
+        public Models.GetChargeResponse CreateCharge(
+                Models.CreateChargeRequest request,
+                string idempotencyKey = null)
+        {
+            Task<Models.GetChargeResponse> t = this.CreateChargeAsync(request, idempotencyKey);
+            ApiHelper.RunTaskSynchronously(t);
+            return t.Result;
+        }
+
+        /// <summary>
+        /// Creates a new charge.
+        /// </summary>
+        /// <param name="request">Required parameter: Request for creating a charge.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetChargeResponse response from the API call.</returns>
+        public async Task<Models.GetChargeResponse> CreateChargeAsync(
+                Models.CreateChargeRequest request,
+                string idempotencyKey = null,
+                CancellationToken cancellationToken = default)
+        {
+            // the base uri for api requests.
+            string baseUri = this.Config.GetBaseUri();
+
+            // prepare query string for API call.
+            StringBuilder queryBuilder = new StringBuilder(baseUri);
+            queryBuilder.Append("/Charges");
+
+            // append request with appropriate headers and parameters
+            var headers = new Dictionary<string, string>()
+            {
+                { "user-agent", this.UserAgent },
+                { "accept", "application/json" },
+                { "content-type", "application/json; charset=utf-8" },
+                { "idempotency-key", idempotencyKey },
+            };
+
+            // append body params.
+            var bodyText = ApiHelper.JsonSerialize(request);
+
+            // prepare the API call request to fetch the response.
+            HttpRequest httpRequest = this.GetClientInstance().PostBody(queryBuilder.ToString(), headers, bodyText);
+
+            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
+
+            // invoke request and get response.
+            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+            HttpContext context = new HttpContext(httpRequest, response);
+
+            // handle errors defined at the API level.
+            this.ValidateResponse(response, context);
+
+            return ApiHelper.JsonDeserialize<Models.GetChargeResponse>(response.Body);
+        }
+
+        /// <summary>
         /// GetChargeTransactions EndPoint.
         /// </summary>
         /// <param name="chargeId">Required parameter: Charge Id.</param>
@@ -252,33 +452,33 @@ namespace PagarmeApiSDK.Standard.Controllers
         }
 
         /// <summary>
-        /// Updates the due date from a charge.
+        /// Captures a charge.
         /// </summary>
-        /// <param name="chargeId">Required parameter: Charge Id.</param>
-        /// <param name="request">Required parameter: Request for updating the due date.</param>
+        /// <param name="chargeId">Required parameter: Charge id.</param>
+        /// <param name="request">Optional parameter: Request for capturing a charge.</param>
         /// <param name="idempotencyKey">Optional parameter: Example: .</param>
         /// <returns>Returns the Models.GetChargeResponse response from the API call.</returns>
-        public Models.GetChargeResponse UpdateChargeDueDate(
+        public Models.GetChargeResponse CaptureCharge(
                 string chargeId,
-                Models.UpdateChargeDueDateRequest request,
+                Models.CreateCaptureChargeRequest request = null,
                 string idempotencyKey = null)
         {
-            Task<Models.GetChargeResponse> t = this.UpdateChargeDueDateAsync(chargeId, request, idempotencyKey);
+            Task<Models.GetChargeResponse> t = this.CaptureChargeAsync(chargeId, request, idempotencyKey);
             ApiHelper.RunTaskSynchronously(t);
             return t.Result;
         }
 
         /// <summary>
-        /// Updates the due date from a charge.
+        /// Captures a charge.
         /// </summary>
-        /// <param name="chargeId">Required parameter: Charge Id.</param>
-        /// <param name="request">Required parameter: Request for updating the due date.</param>
+        /// <param name="chargeId">Required parameter: Charge id.</param>
+        /// <param name="request">Optional parameter: Request for capturing a charge.</param>
         /// <param name="idempotencyKey">Optional parameter: Example: .</param>
         /// <param name="cancellationToken"> cancellationToken. </param>
         /// <returns>Returns the Models.GetChargeResponse response from the API call.</returns>
-        public async Task<Models.GetChargeResponse> UpdateChargeDueDateAsync(
+        public async Task<Models.GetChargeResponse> CaptureChargeAsync(
                 string chargeId,
-                Models.UpdateChargeDueDateRequest request,
+                Models.CreateCaptureChargeRequest request = null,
                 string idempotencyKey = null,
                 CancellationToken cancellationToken = default)
         {
@@ -287,7 +487,7 @@ namespace PagarmeApiSDK.Standard.Controllers
 
             // prepare query string for API call.
             StringBuilder queryBuilder = new StringBuilder(baseUri);
-            queryBuilder.Append("/Charges/{charge_id}/due-date");
+            queryBuilder.Append("/charges/{charge_id}/capture");
 
             // process optional template parameters.
             ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
@@ -308,7 +508,136 @@ namespace PagarmeApiSDK.Standard.Controllers
             var bodyText = ApiHelper.JsonSerialize(request);
 
             // prepare the API call request to fetch the response.
-            HttpRequest httpRequest = this.GetClientInstance().PatchBody(queryBuilder.ToString(), headers, bodyText);
+            HttpRequest httpRequest = this.GetClientInstance().PostBody(queryBuilder.ToString(), headers, bodyText);
+
+            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
+
+            // invoke request and get response.
+            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+            HttpContext context = new HttpContext(httpRequest, response);
+
+            // handle errors defined at the API level.
+            this.ValidateResponse(response, context);
+
+            return ApiHelper.JsonDeserialize<Models.GetChargeResponse>(response.Body);
+        }
+
+        /// <summary>
+        /// Get a charge from its id.
+        /// </summary>
+        /// <param name="chargeId">Required parameter: Charge id.</param>
+        /// <returns>Returns the Models.GetChargeResponse response from the API call.</returns>
+        public Models.GetChargeResponse GetCharge(
+                string chargeId)
+        {
+            Task<Models.GetChargeResponse> t = this.GetChargeAsync(chargeId);
+            ApiHelper.RunTaskSynchronously(t);
+            return t.Result;
+        }
+
+        /// <summary>
+        /// Get a charge from its id.
+        /// </summary>
+        /// <param name="chargeId">Required parameter: Charge id.</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetChargeResponse response from the API call.</returns>
+        public async Task<Models.GetChargeResponse> GetChargeAsync(
+                string chargeId,
+                CancellationToken cancellationToken = default)
+        {
+            // the base uri for api requests.
+            string baseUri = this.Config.GetBaseUri();
+
+            // prepare query string for API call.
+            StringBuilder queryBuilder = new StringBuilder(baseUri);
+            queryBuilder.Append("/charges/{charge_id}");
+
+            // process optional template parameters.
+            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
+            {
+                { "charge_id", chargeId },
+            });
+
+            // append request with appropriate headers and parameters
+            var headers = new Dictionary<string, string>()
+            {
+                { "user-agent", this.UserAgent },
+                { "accept", "application/json" },
+            };
+
+            // prepare the API call request to fetch the response.
+            HttpRequest httpRequest = this.GetClientInstance().Get(queryBuilder.ToString(), headers);
+
+            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
+
+            // invoke request and get response.
+            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+            HttpContext context = new HttpContext(httpRequest, response);
+
+            // handle errors defined at the API level.
+            this.ValidateResponse(response, context);
+
+            return ApiHelper.JsonDeserialize<Models.GetChargeResponse>(response.Body);
+        }
+
+        /// <summary>
+        /// Cancel a charge.
+        /// </summary>
+        /// <param name="chargeId">Required parameter: Charge id.</param>
+        /// <param name="request">Optional parameter: Request for cancelling a charge.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <returns>Returns the Models.GetChargeResponse response from the API call.</returns>
+        public Models.GetChargeResponse CancelCharge(
+                string chargeId,
+                Models.CreateCancelChargeRequest request = null,
+                string idempotencyKey = null)
+        {
+            Task<Models.GetChargeResponse> t = this.CancelChargeAsync(chargeId, request, idempotencyKey);
+            ApiHelper.RunTaskSynchronously(t);
+            return t.Result;
+        }
+
+        /// <summary>
+        /// Cancel a charge.
+        /// </summary>
+        /// <param name="chargeId">Required parameter: Charge id.</param>
+        /// <param name="request">Optional parameter: Request for cancelling a charge.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetChargeResponse response from the API call.</returns>
+        public async Task<Models.GetChargeResponse> CancelChargeAsync(
+                string chargeId,
+                Models.CreateCancelChargeRequest request = null,
+                string idempotencyKey = null,
+                CancellationToken cancellationToken = default)
+        {
+            // the base uri for api requests.
+            string baseUri = this.Config.GetBaseUri();
+
+            // prepare query string for API call.
+            StringBuilder queryBuilder = new StringBuilder(baseUri);
+            queryBuilder.Append("/charges/{charge_id}");
+
+            // process optional template parameters.
+            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
+            {
+                { "charge_id", chargeId },
+            });
+
+            // append request with appropriate headers and parameters
+            var headers = new Dictionary<string, string>()
+            {
+                { "user-agent", this.UserAgent },
+                { "accept", "application/json" },
+                { "content-type", "application/json; charset=utf-8" },
+                { "idempotency-key", idempotencyKey },
+            };
+
+            // append body params.
+            var bodyText = ApiHelper.JsonSerialize(request);
+
+            // prepare the API call request to fetch the response.
+            HttpRequest httpRequest = this.GetClientInstance().DeleteBody(queryBuilder.ToString(), headers, bodyText);
 
             httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
 
@@ -421,469 +750,6 @@ namespace PagarmeApiSDK.Standard.Controllers
         }
 
         /// <summary>
-        /// Captures a charge.
-        /// </summary>
-        /// <param name="chargeId">Required parameter: Charge id.</param>
-        /// <param name="request">Optional parameter: Request for capturing a charge.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <returns>Returns the Models.GetChargeResponse response from the API call.</returns>
-        public Models.GetChargeResponse CaptureCharge(
-                string chargeId,
-                Models.CreateCaptureChargeRequest request = null,
-                string idempotencyKey = null)
-        {
-            Task<Models.GetChargeResponse> t = this.CaptureChargeAsync(chargeId, request, idempotencyKey);
-            ApiHelper.RunTaskSynchronously(t);
-            return t.Result;
-        }
-
-        /// <summary>
-        /// Captures a charge.
-        /// </summary>
-        /// <param name="chargeId">Required parameter: Charge id.</param>
-        /// <param name="request">Optional parameter: Request for capturing a charge.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetChargeResponse response from the API call.</returns>
-        public async Task<Models.GetChargeResponse> CaptureChargeAsync(
-                string chargeId,
-                Models.CreateCaptureChargeRequest request = null,
-                string idempotencyKey = null,
-                CancellationToken cancellationToken = default)
-        {
-            // the base uri for api requests.
-            string baseUri = this.Config.GetBaseUri();
-
-            // prepare query string for API call.
-            StringBuilder queryBuilder = new StringBuilder(baseUri);
-            queryBuilder.Append("/charges/{charge_id}/capture");
-
-            // process optional template parameters.
-            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
-            {
-                { "charge_id", chargeId },
-            });
-
-            // append request with appropriate headers and parameters
-            var headers = new Dictionary<string, string>()
-            {
-                { "user-agent", this.UserAgent },
-                { "accept", "application/json" },
-                { "content-type", "application/json; charset=utf-8" },
-                { "idempotency-key", idempotencyKey },
-            };
-
-            // append body params.
-            var bodyText = ApiHelper.JsonSerialize(request);
-
-            // prepare the API call request to fetch the response.
-            HttpRequest httpRequest = this.GetClientInstance().PostBody(queryBuilder.ToString(), headers, bodyText);
-
-            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
-
-            // invoke request and get response.
-            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
-            HttpContext context = new HttpContext(httpRequest, response);
-
-            // handle errors defined at the API level.
-            this.ValidateResponse(response, context);
-
-            return ApiHelper.JsonDeserialize<Models.GetChargeResponse>(response.Body);
-        }
-
-        /// <summary>
-        /// Updates the card from a charge.
-        /// </summary>
-        /// <param name="chargeId">Required parameter: Charge id.</param>
-        /// <param name="request">Required parameter: Request for updating a charge's card.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <returns>Returns the Models.GetChargeResponse response from the API call.</returns>
-        public Models.GetChargeResponse UpdateChargeCard(
-                string chargeId,
-                Models.UpdateChargeCardRequest request,
-                string idempotencyKey = null)
-        {
-            Task<Models.GetChargeResponse> t = this.UpdateChargeCardAsync(chargeId, request, idempotencyKey);
-            ApiHelper.RunTaskSynchronously(t);
-            return t.Result;
-        }
-
-        /// <summary>
-        /// Updates the card from a charge.
-        /// </summary>
-        /// <param name="chargeId">Required parameter: Charge id.</param>
-        /// <param name="request">Required parameter: Request for updating a charge's card.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetChargeResponse response from the API call.</returns>
-        public async Task<Models.GetChargeResponse> UpdateChargeCardAsync(
-                string chargeId,
-                Models.UpdateChargeCardRequest request,
-                string idempotencyKey = null,
-                CancellationToken cancellationToken = default)
-        {
-            // the base uri for api requests.
-            string baseUri = this.Config.GetBaseUri();
-
-            // prepare query string for API call.
-            StringBuilder queryBuilder = new StringBuilder(baseUri);
-            queryBuilder.Append("/charges/{charge_id}/card");
-
-            // process optional template parameters.
-            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
-            {
-                { "charge_id", chargeId },
-            });
-
-            // append request with appropriate headers and parameters
-            var headers = new Dictionary<string, string>()
-            {
-                { "user-agent", this.UserAgent },
-                { "accept", "application/json" },
-                { "content-type", "application/json; charset=utf-8" },
-                { "idempotency-key", idempotencyKey },
-            };
-
-            // append body params.
-            var bodyText = ApiHelper.JsonSerialize(request);
-
-            // prepare the API call request to fetch the response.
-            HttpRequest httpRequest = this.GetClientInstance().PatchBody(queryBuilder.ToString(), headers, bodyText);
-
-            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
-
-            // invoke request and get response.
-            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
-            HttpContext context = new HttpContext(httpRequest, response);
-
-            // handle errors defined at the API level.
-            this.ValidateResponse(response, context);
-
-            return ApiHelper.JsonDeserialize<Models.GetChargeResponse>(response.Body);
-        }
-
-        /// <summary>
-        /// Get a charge from its id.
-        /// </summary>
-        /// <param name="chargeId">Required parameter: Charge id.</param>
-        /// <returns>Returns the Models.GetChargeResponse response from the API call.</returns>
-        public Models.GetChargeResponse GetCharge(
-                string chargeId)
-        {
-            Task<Models.GetChargeResponse> t = this.GetChargeAsync(chargeId);
-            ApiHelper.RunTaskSynchronously(t);
-            return t.Result;
-        }
-
-        /// <summary>
-        /// Get a charge from its id.
-        /// </summary>
-        /// <param name="chargeId">Required parameter: Charge id.</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetChargeResponse response from the API call.</returns>
-        public async Task<Models.GetChargeResponse> GetChargeAsync(
-                string chargeId,
-                CancellationToken cancellationToken = default)
-        {
-            // the base uri for api requests.
-            string baseUri = this.Config.GetBaseUri();
-
-            // prepare query string for API call.
-            StringBuilder queryBuilder = new StringBuilder(baseUri);
-            queryBuilder.Append("/charges/{charge_id}");
-
-            // process optional template parameters.
-            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
-            {
-                { "charge_id", chargeId },
-            });
-
-            // append request with appropriate headers and parameters
-            var headers = new Dictionary<string, string>()
-            {
-                { "user-agent", this.UserAgent },
-                { "accept", "application/json" },
-            };
-
-            // prepare the API call request to fetch the response.
-            HttpRequest httpRequest = this.GetClientInstance().Get(queryBuilder.ToString(), headers);
-
-            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
-
-            // invoke request and get response.
-            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
-            HttpContext context = new HttpContext(httpRequest, response);
-
-            // handle errors defined at the API level.
-            this.ValidateResponse(response, context);
-
-            return ApiHelper.JsonDeserialize<Models.GetChargeResponse>(response.Body);
-        }
-
-        /// <summary>
-        /// GetChargesSummary EndPoint.
-        /// </summary>
-        /// <param name="status">Required parameter: Example: .</param>
-        /// <param name="createdSince">Optional parameter: Example: .</param>
-        /// <param name="createdUntil">Optional parameter: Example: .</param>
-        /// <returns>Returns the Models.GetChargesSummaryResponse response from the API call.</returns>
-        public Models.GetChargesSummaryResponse GetChargesSummary(
-                string status,
-                DateTime? createdSince = null,
-                DateTime? createdUntil = null)
-        {
-            Task<Models.GetChargesSummaryResponse> t = this.GetChargesSummaryAsync(status, createdSince, createdUntil);
-            ApiHelper.RunTaskSynchronously(t);
-            return t.Result;
-        }
-
-        /// <summary>
-        /// GetChargesSummary EndPoint.
-        /// </summary>
-        /// <param name="status">Required parameter: Example: .</param>
-        /// <param name="createdSince">Optional parameter: Example: .</param>
-        /// <param name="createdUntil">Optional parameter: Example: .</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetChargesSummaryResponse response from the API call.</returns>
-        public async Task<Models.GetChargesSummaryResponse> GetChargesSummaryAsync(
-                string status,
-                DateTime? createdSince = null,
-                DateTime? createdUntil = null,
-                CancellationToken cancellationToken = default)
-        {
-            // the base uri for api requests.
-            string baseUri = this.Config.GetBaseUri();
-
-            // prepare query string for API call.
-            StringBuilder queryBuilder = new StringBuilder(baseUri);
-            queryBuilder.Append("/charges/summary");
-
-            // prepare specfied query parameters.
-            var queryParams = new Dictionary<string, object>()
-            {
-                { "status", status },
-                { "created_since", createdSince.HasValue ? createdSince.Value.ToString("yyyy'-'MM'-'dd'T'HH':'mm':'ss.FFFFFFFK") : null },
-                { "created_until", createdUntil.HasValue ? createdUntil.Value.ToString("yyyy'-'MM'-'dd'T'HH':'mm':'ss.FFFFFFFK") : null },
-            };
-
-            // append request with appropriate headers and parameters
-            var headers = new Dictionary<string, string>()
-            {
-                { "user-agent", this.UserAgent },
-                { "accept", "application/json" },
-            };
-
-            // prepare the API call request to fetch the response.
-            HttpRequest httpRequest = this.GetClientInstance().Get(queryBuilder.ToString(), headers, queryParameters: queryParams);
-
-            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
-
-            // invoke request and get response.
-            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
-            HttpContext context = new HttpContext(httpRequest, response);
-
-            // handle errors defined at the API level.
-            this.ValidateResponse(response, context);
-
-            return ApiHelper.JsonDeserialize<Models.GetChargesSummaryResponse>(response.Body);
-        }
-
-        /// <summary>
-        /// Retries a charge.
-        /// </summary>
-        /// <param name="chargeId">Required parameter: Charge id.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <returns>Returns the Models.GetChargeResponse response from the API call.</returns>
-        public Models.GetChargeResponse RetryCharge(
-                string chargeId,
-                string idempotencyKey = null)
-        {
-            Task<Models.GetChargeResponse> t = this.RetryChargeAsync(chargeId, idempotencyKey);
-            ApiHelper.RunTaskSynchronously(t);
-            return t.Result;
-        }
-
-        /// <summary>
-        /// Retries a charge.
-        /// </summary>
-        /// <param name="chargeId">Required parameter: Charge id.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetChargeResponse response from the API call.</returns>
-        public async Task<Models.GetChargeResponse> RetryChargeAsync(
-                string chargeId,
-                string idempotencyKey = null,
-                CancellationToken cancellationToken = default)
-        {
-            // the base uri for api requests.
-            string baseUri = this.Config.GetBaseUri();
-
-            // prepare query string for API call.
-            StringBuilder queryBuilder = new StringBuilder(baseUri);
-            queryBuilder.Append("/charges/{charge_id}/retry");
-
-            // process optional template parameters.
-            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
-            {
-                { "charge_id", chargeId },
-            });
-
-            // append request with appropriate headers and parameters
-            var headers = new Dictionary<string, string>()
-            {
-                { "user-agent", this.UserAgent },
-                { "accept", "application/json" },
-                { "idempotency-key", idempotencyKey },
-            };
-
-            // prepare the API call request to fetch the response.
-            HttpRequest httpRequest = this.GetClientInstance().Post(queryBuilder.ToString(), headers, null);
-
-            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
-
-            // invoke request and get response.
-            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
-            HttpContext context = new HttpContext(httpRequest, response);
-
-            // handle errors defined at the API level.
-            this.ValidateResponse(response, context);
-
-            return ApiHelper.JsonDeserialize<Models.GetChargeResponse>(response.Body);
-        }
-
-        /// <summary>
-        /// Cancel a charge.
-        /// </summary>
-        /// <param name="chargeId">Required parameter: Charge id.</param>
-        /// <param name="request">Optional parameter: Request for cancelling a charge.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <returns>Returns the Models.GetChargeResponse response from the API call.</returns>
-        public Models.GetChargeResponse CancelCharge(
-                string chargeId,
-                Models.CreateCancelChargeRequest request = null,
-                string idempotencyKey = null)
-        {
-            Task<Models.GetChargeResponse> t = this.CancelChargeAsync(chargeId, request, idempotencyKey);
-            ApiHelper.RunTaskSynchronously(t);
-            return t.Result;
-        }
-
-        /// <summary>
-        /// Cancel a charge.
-        /// </summary>
-        /// <param name="chargeId">Required parameter: Charge id.</param>
-        /// <param name="request">Optional parameter: Request for cancelling a charge.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetChargeResponse response from the API call.</returns>
-        public async Task<Models.GetChargeResponse> CancelChargeAsync(
-                string chargeId,
-                Models.CreateCancelChargeRequest request = null,
-                string idempotencyKey = null,
-                CancellationToken cancellationToken = default)
-        {
-            // the base uri for api requests.
-            string baseUri = this.Config.GetBaseUri();
-
-            // prepare query string for API call.
-            StringBuilder queryBuilder = new StringBuilder(baseUri);
-            queryBuilder.Append("/charges/{charge_id}");
-
-            // process optional template parameters.
-            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
-            {
-                { "charge_id", chargeId },
-            });
-
-            // append request with appropriate headers and parameters
-            var headers = new Dictionary<string, string>()
-            {
-                { "user-agent", this.UserAgent },
-                { "accept", "application/json" },
-                { "content-type", "application/json; charset=utf-8" },
-                { "idempotency-key", idempotencyKey },
-            };
-
-            // append body params.
-            var bodyText = ApiHelper.JsonSerialize(request);
-
-            // prepare the API call request to fetch the response.
-            HttpRequest httpRequest = this.GetClientInstance().DeleteBody(queryBuilder.ToString(), headers, bodyText);
-
-            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
-
-            // invoke request and get response.
-            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
-            HttpContext context = new HttpContext(httpRequest, response);
-
-            // handle errors defined at the API level.
-            this.ValidateResponse(response, context);
-
-            return ApiHelper.JsonDeserialize<Models.GetChargeResponse>(response.Body);
-        }
-
-        /// <summary>
-        /// Creates a new charge.
-        /// </summary>
-        /// <param name="request">Required parameter: Request for creating a charge.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <returns>Returns the Models.GetChargeResponse response from the API call.</returns>
-        public Models.GetChargeResponse CreateCharge(
-                Models.CreateChargeRequest request,
-                string idempotencyKey = null)
-        {
-            Task<Models.GetChargeResponse> t = this.CreateChargeAsync(request, idempotencyKey);
-            ApiHelper.RunTaskSynchronously(t);
-            return t.Result;
-        }
-
-        /// <summary>
-        /// Creates a new charge.
-        /// </summary>
-        /// <param name="request">Required parameter: Request for creating a charge.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetChargeResponse response from the API call.</returns>
-        public async Task<Models.GetChargeResponse> CreateChargeAsync(
-                Models.CreateChargeRequest request,
-                string idempotencyKey = null,
-                CancellationToken cancellationToken = default)
-        {
-            // the base uri for api requests.
-            string baseUri = this.Config.GetBaseUri();
-
-            // prepare query string for API call.
-            StringBuilder queryBuilder = new StringBuilder(baseUri);
-            queryBuilder.Append("/Charges");
-
-            // append request with appropriate headers and parameters
-            var headers = new Dictionary<string, string>()
-            {
-                { "user-agent", this.UserAgent },
-                { "accept", "application/json" },
-                { "content-type", "application/json; charset=utf-8" },
-                { "idempotency-key", idempotencyKey },
-            };
-
-            // append body params.
-            var bodyText = ApiHelper.JsonSerialize(request);
-
-            // prepare the API call request to fetch the response.
-            HttpRequest httpRequest = this.GetClientInstance().PostBody(queryBuilder.ToString(), headers, bodyText);
-
-            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
-
-            // invoke request and get response.
-            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
-            HttpContext context = new HttpContext(httpRequest, response);
-
-            // handle errors defined at the API level.
-            this.ValidateResponse(response, context);
-
-            return ApiHelper.JsonDeserialize<Models.GetChargeResponse>(response.Body);
-        }
-
-        /// <summary>
         /// ConfirmPayment EndPoint.
         /// </summary>
         /// <param name="chargeId">Required parameter: Example: .</param>
@@ -941,6 +807,140 @@ namespace PagarmeApiSDK.Standard.Controllers
 
             // prepare the API call request to fetch the response.
             HttpRequest httpRequest = this.GetClientInstance().PostBody(queryBuilder.ToString(), headers, bodyText);
+
+            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
+
+            // invoke request and get response.
+            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+            HttpContext context = new HttpContext(httpRequest, response);
+
+            // handle errors defined at the API level.
+            this.ValidateResponse(response, context);
+
+            return ApiHelper.JsonDeserialize<Models.GetChargeResponse>(response.Body);
+        }
+
+        /// <summary>
+        /// Updates the due date from a charge.
+        /// </summary>
+        /// <param name="chargeId">Required parameter: Charge Id.</param>
+        /// <param name="request">Required parameter: Request for updating the due date.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <returns>Returns the Models.GetChargeResponse response from the API call.</returns>
+        public Models.GetChargeResponse UpdateChargeDueDate(
+                string chargeId,
+                Models.UpdateChargeDueDateRequest request,
+                string idempotencyKey = null)
+        {
+            Task<Models.GetChargeResponse> t = this.UpdateChargeDueDateAsync(chargeId, request, idempotencyKey);
+            ApiHelper.RunTaskSynchronously(t);
+            return t.Result;
+        }
+
+        /// <summary>
+        /// Updates the due date from a charge.
+        /// </summary>
+        /// <param name="chargeId">Required parameter: Charge Id.</param>
+        /// <param name="request">Required parameter: Request for updating the due date.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetChargeResponse response from the API call.</returns>
+        public async Task<Models.GetChargeResponse> UpdateChargeDueDateAsync(
+                string chargeId,
+                Models.UpdateChargeDueDateRequest request,
+                string idempotencyKey = null,
+                CancellationToken cancellationToken = default)
+        {
+            // the base uri for api requests.
+            string baseUri = this.Config.GetBaseUri();
+
+            // prepare query string for API call.
+            StringBuilder queryBuilder = new StringBuilder(baseUri);
+            queryBuilder.Append("/Charges/{charge_id}/due-date");
+
+            // process optional template parameters.
+            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
+            {
+                { "charge_id", chargeId },
+            });
+
+            // append request with appropriate headers and parameters
+            var headers = new Dictionary<string, string>()
+            {
+                { "user-agent", this.UserAgent },
+                { "accept", "application/json" },
+                { "content-type", "application/json; charset=utf-8" },
+                { "idempotency-key", idempotencyKey },
+            };
+
+            // append body params.
+            var bodyText = ApiHelper.JsonSerialize(request);
+
+            // prepare the API call request to fetch the response.
+            HttpRequest httpRequest = this.GetClientInstance().PatchBody(queryBuilder.ToString(), headers, bodyText);
+
+            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
+
+            // invoke request and get response.
+            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+            HttpContext context = new HttpContext(httpRequest, response);
+
+            // handle errors defined at the API level.
+            this.ValidateResponse(response, context);
+
+            return ApiHelper.JsonDeserialize<Models.GetChargeResponse>(response.Body);
+        }
+
+        /// <summary>
+        /// Retries a charge.
+        /// </summary>
+        /// <param name="chargeId">Required parameter: Charge id.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <returns>Returns the Models.GetChargeResponse response from the API call.</returns>
+        public Models.GetChargeResponse RetryCharge(
+                string chargeId,
+                string idempotencyKey = null)
+        {
+            Task<Models.GetChargeResponse> t = this.RetryChargeAsync(chargeId, idempotencyKey);
+            ApiHelper.RunTaskSynchronously(t);
+            return t.Result;
+        }
+
+        /// <summary>
+        /// Retries a charge.
+        /// </summary>
+        /// <param name="chargeId">Required parameter: Charge id.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetChargeResponse response from the API call.</returns>
+        public async Task<Models.GetChargeResponse> RetryChargeAsync(
+                string chargeId,
+                string idempotencyKey = null,
+                CancellationToken cancellationToken = default)
+        {
+            // the base uri for api requests.
+            string baseUri = this.Config.GetBaseUri();
+
+            // prepare query string for API call.
+            StringBuilder queryBuilder = new StringBuilder(baseUri);
+            queryBuilder.Append("/charges/{charge_id}/retry");
+
+            // process optional template parameters.
+            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
+            {
+                { "charge_id", chargeId },
+            });
+
+            // append request with appropriate headers and parameters
+            var headers = new Dictionary<string, string>()
+            {
+                { "user-agent", this.UserAgent },
+                { "accept", "application/json" },
+                { "idempotency-key", idempotencyKey },
+            };
+
+            // prepare the API call request to fetch the response.
+            HttpRequest httpRequest = this.GetClientInstance().Post(queryBuilder.ToString(), headers, null);
 
             httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
 

--- a/PagarmeApiSDK.Standard/Controllers/CustomersController.cs
+++ b/PagarmeApiSDK.Standard/Controllers/CustomersController.cs
@@ -257,67 +257,6 @@ namespace PagarmeApiSDK.Standard.Controllers
         }
 
         /// <summary>
-        /// Creates a new customer.
-        /// </summary>
-        /// <param name="request">Required parameter: Request for creating a customer.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <returns>Returns the Models.GetCustomerResponse response from the API call.</returns>
-        public Models.GetCustomerResponse CreateCustomer(
-                Models.CreateCustomerRequest request,
-                string idempotencyKey = null)
-        {
-            Task<Models.GetCustomerResponse> t = this.CreateCustomerAsync(request, idempotencyKey);
-            ApiHelper.RunTaskSynchronously(t);
-            return t.Result;
-        }
-
-        /// <summary>
-        /// Creates a new customer.
-        /// </summary>
-        /// <param name="request">Required parameter: Request for creating a customer.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetCustomerResponse response from the API call.</returns>
-        public async Task<Models.GetCustomerResponse> CreateCustomerAsync(
-                Models.CreateCustomerRequest request,
-                string idempotencyKey = null,
-                CancellationToken cancellationToken = default)
-        {
-            // the base uri for api requests.
-            string baseUri = this.Config.GetBaseUri();
-
-            // prepare query string for API call.
-            StringBuilder queryBuilder = new StringBuilder(baseUri);
-            queryBuilder.Append("/customers");
-
-            // append request with appropriate headers and parameters
-            var headers = new Dictionary<string, string>()
-            {
-                { "user-agent", this.UserAgent },
-                { "accept", "application/json" },
-                { "content-type", "application/json; charset=utf-8" },
-                { "idempotency-key", idempotencyKey },
-            };
-
-            // append body params.
-            var bodyText = ApiHelper.JsonSerialize(request);
-
-            // prepare the API call request to fetch the response.
-            HttpRequest httpRequest = this.GetClientInstance().PostBody(queryBuilder.ToString(), headers, bodyText);
-
-            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
-
-            // invoke request and get response.
-            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
-            HttpContext context = new HttpContext(httpRequest, response);
-
-            // handle errors defined at the API level.
-            this.ValidateResponse(response, context);
-
-            return ApiHelper.JsonDeserialize<Models.GetCustomerResponse>(response.Body);
-        }
-
-        /// <summary>
         /// Creates a new address for a customer.
         /// </summary>
         /// <param name="customerId">Required parameter: Customer Id.</param>
@@ -389,26 +328,30 @@ namespace PagarmeApiSDK.Standard.Controllers
         }
 
         /// <summary>
-        /// Delete a Customer's access tokens.
+        /// Creates a new customer.
         /// </summary>
-        /// <param name="customerId">Required parameter: Customer Id.</param>
-        /// <returns>Returns the Models.ListAccessTokensResponse response from the API call.</returns>
-        public Models.ListAccessTokensResponse DeleteAccessTokens(
-                string customerId)
+        /// <param name="request">Required parameter: Request for creating a customer.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <returns>Returns the Models.GetCustomerResponse response from the API call.</returns>
+        public Models.GetCustomerResponse CreateCustomer(
+                Models.CreateCustomerRequest request,
+                string idempotencyKey = null)
         {
-            Task<Models.ListAccessTokensResponse> t = this.DeleteAccessTokensAsync(customerId);
+            Task<Models.GetCustomerResponse> t = this.CreateCustomerAsync(request, idempotencyKey);
             ApiHelper.RunTaskSynchronously(t);
             return t.Result;
         }
 
         /// <summary>
-        /// Delete a Customer's access tokens.
+        /// Creates a new customer.
         /// </summary>
-        /// <param name="customerId">Required parameter: Customer Id.</param>
+        /// <param name="request">Required parameter: Request for creating a customer.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
         /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.ListAccessTokensResponse response from the API call.</returns>
-        public async Task<Models.ListAccessTokensResponse> DeleteAccessTokensAsync(
-                string customerId,
+        /// <returns>Returns the Models.GetCustomerResponse response from the API call.</returns>
+        public async Task<Models.GetCustomerResponse> CreateCustomerAsync(
+                Models.CreateCustomerRequest request,
+                string idempotencyKey = null,
                 CancellationToken cancellationToken = default)
         {
             // the base uri for api requests.
@@ -416,7 +359,72 @@ namespace PagarmeApiSDK.Standard.Controllers
 
             // prepare query string for API call.
             StringBuilder queryBuilder = new StringBuilder(baseUri);
-            queryBuilder.Append("/customers/{customer_id}/access-tokens/");
+            queryBuilder.Append("/customers");
+
+            // append request with appropriate headers and parameters
+            var headers = new Dictionary<string, string>()
+            {
+                { "user-agent", this.UserAgent },
+                { "accept", "application/json" },
+                { "content-type", "application/json; charset=utf-8" },
+                { "idempotency-key", idempotencyKey },
+            };
+
+            // append body params.
+            var bodyText = ApiHelper.JsonSerialize(request);
+
+            // prepare the API call request to fetch the response.
+            HttpRequest httpRequest = this.GetClientInstance().PostBody(queryBuilder.ToString(), headers, bodyText);
+
+            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
+
+            // invoke request and get response.
+            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+            HttpContext context = new HttpContext(httpRequest, response);
+
+            // handle errors defined at the API level.
+            this.ValidateResponse(response, context);
+
+            return ApiHelper.JsonDeserialize<Models.GetCustomerResponse>(response.Body);
+        }
+
+        /// <summary>
+        /// Creates a new card for a customer.
+        /// </summary>
+        /// <param name="customerId">Required parameter: Customer id.</param>
+        /// <param name="request">Required parameter: Request for creating a card.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <returns>Returns the Models.GetCardResponse response from the API call.</returns>
+        public Models.GetCardResponse CreateCard(
+                string customerId,
+                Models.CreateCardRequest request,
+                string idempotencyKey = null)
+        {
+            Task<Models.GetCardResponse> t = this.CreateCardAsync(customerId, request, idempotencyKey);
+            ApiHelper.RunTaskSynchronously(t);
+            return t.Result;
+        }
+
+        /// <summary>
+        /// Creates a new card for a customer.
+        /// </summary>
+        /// <param name="customerId">Required parameter: Customer id.</param>
+        /// <param name="request">Required parameter: Request for creating a card.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetCardResponse response from the API call.</returns>
+        public async Task<Models.GetCardResponse> CreateCardAsync(
+                string customerId,
+                Models.CreateCardRequest request,
+                string idempotencyKey = null,
+                CancellationToken cancellationToken = default)
+        {
+            // the base uri for api requests.
+            string baseUri = this.Config.GetBaseUri();
+
+            // prepare query string for API call.
+            StringBuilder queryBuilder = new StringBuilder(baseUri);
+            queryBuilder.Append("/customers/{customer_id}/cards");
 
             // process optional template parameters.
             ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
@@ -429,10 +437,15 @@ namespace PagarmeApiSDK.Standard.Controllers
             {
                 { "user-agent", this.UserAgent },
                 { "accept", "application/json" },
+                { "content-type", "application/json; charset=utf-8" },
+                { "idempotency-key", idempotencyKey },
             };
 
+            // append body params.
+            var bodyText = ApiHelper.JsonSerialize(request);
+
             // prepare the API call request to fetch the response.
-            HttpRequest httpRequest = this.GetClientInstance().Get(queryBuilder.ToString(), headers);
+            HttpRequest httpRequest = this.GetClientInstance().PostBody(queryBuilder.ToString(), headers, bodyText);
 
             httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
 
@@ -443,7 +456,148 @@ namespace PagarmeApiSDK.Standard.Controllers
             // handle errors defined at the API level.
             this.ValidateResponse(response, context);
 
-            return ApiHelper.JsonDeserialize<Models.ListAccessTokensResponse>(response.Body);
+            return ApiHelper.JsonDeserialize<Models.GetCardResponse>(response.Body);
+        }
+
+        /// <summary>
+        /// Get all cards from a customer.
+        /// </summary>
+        /// <param name="customerId">Required parameter: Customer Id.</param>
+        /// <param name="page">Optional parameter: Page number.</param>
+        /// <param name="size">Optional parameter: Page size.</param>
+        /// <returns>Returns the Models.ListCardsResponse response from the API call.</returns>
+        public Models.ListCardsResponse GetCards(
+                string customerId,
+                int? page = null,
+                int? size = null)
+        {
+            Task<Models.ListCardsResponse> t = this.GetCardsAsync(customerId, page, size);
+            ApiHelper.RunTaskSynchronously(t);
+            return t.Result;
+        }
+
+        /// <summary>
+        /// Get all cards from a customer.
+        /// </summary>
+        /// <param name="customerId">Required parameter: Customer Id.</param>
+        /// <param name="page">Optional parameter: Page number.</param>
+        /// <param name="size">Optional parameter: Page size.</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.ListCardsResponse response from the API call.</returns>
+        public async Task<Models.ListCardsResponse> GetCardsAsync(
+                string customerId,
+                int? page = null,
+                int? size = null,
+                CancellationToken cancellationToken = default)
+        {
+            // the base uri for api requests.
+            string baseUri = this.Config.GetBaseUri();
+
+            // prepare query string for API call.
+            StringBuilder queryBuilder = new StringBuilder(baseUri);
+            queryBuilder.Append("/customers/{customer_id}/cards");
+
+            // process optional template parameters.
+            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
+            {
+                { "customer_id", customerId },
+            });
+
+            // prepare specfied query parameters.
+            var queryParams = new Dictionary<string, object>()
+            {
+                { "page", page },
+                { "size", size },
+            };
+
+            // append request with appropriate headers and parameters
+            var headers = new Dictionary<string, string>()
+            {
+                { "user-agent", this.UserAgent },
+                { "accept", "application/json" },
+            };
+
+            // prepare the API call request to fetch the response.
+            HttpRequest httpRequest = this.GetClientInstance().Get(queryBuilder.ToString(), headers, queryParameters: queryParams);
+
+            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
+
+            // invoke request and get response.
+            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+            HttpContext context = new HttpContext(httpRequest, response);
+
+            // handle errors defined at the API level.
+            this.ValidateResponse(response, context);
+
+            return ApiHelper.JsonDeserialize<Models.ListCardsResponse>(response.Body);
+        }
+
+        /// <summary>
+        /// Renew a card.
+        /// </summary>
+        /// <param name="customerId">Required parameter: Customer id.</param>
+        /// <param name="cardId">Required parameter: Card Id.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <returns>Returns the Models.GetCardResponse response from the API call.</returns>
+        public Models.GetCardResponse RenewCard(
+                string customerId,
+                string cardId,
+                string idempotencyKey = null)
+        {
+            Task<Models.GetCardResponse> t = this.RenewCardAsync(customerId, cardId, idempotencyKey);
+            ApiHelper.RunTaskSynchronously(t);
+            return t.Result;
+        }
+
+        /// <summary>
+        /// Renew a card.
+        /// </summary>
+        /// <param name="customerId">Required parameter: Customer id.</param>
+        /// <param name="cardId">Required parameter: Card Id.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetCardResponse response from the API call.</returns>
+        public async Task<Models.GetCardResponse> RenewCardAsync(
+                string customerId,
+                string cardId,
+                string idempotencyKey = null,
+                CancellationToken cancellationToken = default)
+        {
+            // the base uri for api requests.
+            string baseUri = this.Config.GetBaseUri();
+
+            // prepare query string for API call.
+            StringBuilder queryBuilder = new StringBuilder(baseUri);
+            queryBuilder.Append("/customers/{customer_id}/cards/{card_id}/renew");
+
+            // process optional template parameters.
+            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
+            {
+                { "customer_id", customerId },
+                { "card_id", cardId },
+            });
+
+            // append request with appropriate headers and parameters
+            var headers = new Dictionary<string, string>()
+            {
+                { "user-agent", this.UserAgent },
+                { "accept", "application/json" },
+                { "idempotency-key", idempotencyKey },
+            };
+
+            // prepare the API call request to fetch the response.
+            HttpRequest httpRequest = this.GetClientInstance().Post(queryBuilder.ToString(), headers, null);
+
+            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
+
+            // invoke request and get response.
+            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+            HttpContext context = new HttpContext(httpRequest, response);
+
+            // handle errors defined at the API level.
+            this.ValidateResponse(response, context);
+
+            return ApiHelper.JsonDeserialize<Models.GetCardResponse>(response.Body);
         }
 
         /// <summary>
@@ -578,33 +732,96 @@ namespace PagarmeApiSDK.Standard.Controllers
         }
 
         /// <summary>
-        /// Creates a new card for a customer.
+        /// Get a Customer's access token.
         /// </summary>
-        /// <param name="customerId">Required parameter: Customer id.</param>
-        /// <param name="request">Required parameter: Request for creating a card.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <returns>Returns the Models.GetCardResponse response from the API call.</returns>
-        public Models.GetCardResponse CreateCard(
+        /// <param name="customerId">Required parameter: Customer Id.</param>
+        /// <param name="tokenId">Required parameter: Token Id.</param>
+        /// <returns>Returns the Models.GetAccessTokenResponse response from the API call.</returns>
+        public Models.GetAccessTokenResponse GetAccessToken(
                 string customerId,
-                Models.CreateCardRequest request,
-                string idempotencyKey = null)
+                string tokenId)
         {
-            Task<Models.GetCardResponse> t = this.CreateCardAsync(customerId, request, idempotencyKey);
+            Task<Models.GetAccessTokenResponse> t = this.GetAccessTokenAsync(customerId, tokenId);
             ApiHelper.RunTaskSynchronously(t);
             return t.Result;
         }
 
         /// <summary>
-        /// Creates a new card for a customer.
+        /// Get a Customer's access token.
         /// </summary>
-        /// <param name="customerId">Required parameter: Customer id.</param>
-        /// <param name="request">Required parameter: Request for creating a card.</param>
+        /// <param name="customerId">Required parameter: Customer Id.</param>
+        /// <param name="tokenId">Required parameter: Token Id.</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetAccessTokenResponse response from the API call.</returns>
+        public async Task<Models.GetAccessTokenResponse> GetAccessTokenAsync(
+                string customerId,
+                string tokenId,
+                CancellationToken cancellationToken = default)
+        {
+            // the base uri for api requests.
+            string baseUri = this.Config.GetBaseUri();
+
+            // prepare query string for API call.
+            StringBuilder queryBuilder = new StringBuilder(baseUri);
+            queryBuilder.Append("/customers/{customer_id}/access-tokens/{token_id}");
+
+            // process optional template parameters.
+            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
+            {
+                { "customer_id", customerId },
+                { "token_id", tokenId },
+            });
+
+            // append request with appropriate headers and parameters
+            var headers = new Dictionary<string, string>()
+            {
+                { "user-agent", this.UserAgent },
+                { "accept", "application/json" },
+            };
+
+            // prepare the API call request to fetch the response.
+            HttpRequest httpRequest = this.GetClientInstance().Get(queryBuilder.ToString(), headers);
+
+            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
+
+            // invoke request and get response.
+            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+            HttpContext context = new HttpContext(httpRequest, response);
+
+            // handle errors defined at the API level.
+            this.ValidateResponse(response, context);
+
+            return ApiHelper.JsonDeserialize<Models.GetAccessTokenResponse>(response.Body);
+        }
+
+        /// <summary>
+        /// Updates the metadata a customer.
+        /// </summary>
+        /// <param name="customerId">Required parameter: The customer id.</param>
+        /// <param name="request">Required parameter: Request for updating the customer metadata.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <returns>Returns the Models.GetCustomerResponse response from the API call.</returns>
+        public Models.GetCustomerResponse UpdateCustomerMetadata(
+                string customerId,
+                Models.UpdateMetadataRequest request,
+                string idempotencyKey = null)
+        {
+            Task<Models.GetCustomerResponse> t = this.UpdateCustomerMetadataAsync(customerId, request, idempotencyKey);
+            ApiHelper.RunTaskSynchronously(t);
+            return t.Result;
+        }
+
+        /// <summary>
+        /// Updates the metadata a customer.
+        /// </summary>
+        /// <param name="customerId">Required parameter: The customer id.</param>
+        /// <param name="request">Required parameter: Request for updating the customer metadata.</param>
         /// <param name="idempotencyKey">Optional parameter: Example: .</param>
         /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetCardResponse response from the API call.</returns>
-        public async Task<Models.GetCardResponse> CreateCardAsync(
+        /// <returns>Returns the Models.GetCustomerResponse response from the API call.</returns>
+        public async Task<Models.GetCustomerResponse> UpdateCustomerMetadataAsync(
                 string customerId,
-                Models.CreateCardRequest request,
+                Models.UpdateMetadataRequest request,
                 string idempotencyKey = null,
                 CancellationToken cancellationToken = default)
         {
@@ -613,7 +830,7 @@ namespace PagarmeApiSDK.Standard.Controllers
 
             // prepare query string for API call.
             StringBuilder queryBuilder = new StringBuilder(baseUri);
-            queryBuilder.Append("/customers/{customer_id}/cards");
+            queryBuilder.Append("/Customers/{customer_id}/metadata");
 
             // process optional template parameters.
             ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
@@ -634,7 +851,70 @@ namespace PagarmeApiSDK.Standard.Controllers
             var bodyText = ApiHelper.JsonSerialize(request);
 
             // prepare the API call request to fetch the response.
-            HttpRequest httpRequest = this.GetClientInstance().PostBody(queryBuilder.ToString(), headers, bodyText);
+            HttpRequest httpRequest = this.GetClientInstance().PatchBody(queryBuilder.ToString(), headers, bodyText);
+
+            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
+
+            // invoke request and get response.
+            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+            HttpContext context = new HttpContext(httpRequest, response);
+
+            // handle errors defined at the API level.
+            this.ValidateResponse(response, context);
+
+            return ApiHelper.JsonDeserialize<Models.GetCustomerResponse>(response.Body);
+        }
+
+        /// <summary>
+        /// Get a customer's card.
+        /// </summary>
+        /// <param name="customerId">Required parameter: Customer id.</param>
+        /// <param name="cardId">Required parameter: Card id.</param>
+        /// <returns>Returns the Models.GetCardResponse response from the API call.</returns>
+        public Models.GetCardResponse GetCard(
+                string customerId,
+                string cardId)
+        {
+            Task<Models.GetCardResponse> t = this.GetCardAsync(customerId, cardId);
+            ApiHelper.RunTaskSynchronously(t);
+            return t.Result;
+        }
+
+        /// <summary>
+        /// Get a customer's card.
+        /// </summary>
+        /// <param name="customerId">Required parameter: Customer id.</param>
+        /// <param name="cardId">Required parameter: Card id.</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetCardResponse response from the API call.</returns>
+        public async Task<Models.GetCardResponse> GetCardAsync(
+                string customerId,
+                string cardId,
+                CancellationToken cancellationToken = default)
+        {
+            // the base uri for api requests.
+            string baseUri = this.Config.GetBaseUri();
+
+            // prepare query string for API call.
+            StringBuilder queryBuilder = new StringBuilder(baseUri);
+            queryBuilder.Append("/customers/{customer_id}/cards/{card_id}");
+
+            // process optional template parameters.
+            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
+            {
+                { "customer_id", customerId },
+                { "card_id", cardId },
+            });
+
+            // append request with appropriate headers and parameters
+            var headers = new Dictionary<string, string>()
+            {
+                { "user-agent", this.UserAgent },
+                { "accept", "application/json" },
+            };
+
+            // prepare the API call request to fetch the response.
+            HttpRequest httpRequest = this.GetClientInstance().Get(queryBuilder.ToString(), headers);
 
             httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
 
@@ -649,46 +929,26 @@ namespace PagarmeApiSDK.Standard.Controllers
         }
 
         /// <summary>
-        /// Get all Customers.
+        /// Delete a Customer's access tokens.
         /// </summary>
-        /// <param name="name">Optional parameter: Name of the Customer.</param>
-        /// <param name="document">Optional parameter: Document of the Customer.</param>
-        /// <param name="page">Optional parameter: Current page the the search.</param>
-        /// <param name="size">Optional parameter: Quantity pages of the search.</param>
-        /// <param name="email">Optional parameter: Customer's email.</param>
-        /// <param name="code">Optional parameter: Customer's code.</param>
-        /// <returns>Returns the Models.ListCustomersResponse response from the API call.</returns>
-        public Models.ListCustomersResponse GetCustomers(
-                string name = null,
-                string document = null,
-                int? page = 1,
-                int? size = 10,
-                string email = null,
-                string code = null)
+        /// <param name="customerId">Required parameter: Customer Id.</param>
+        /// <returns>Returns the Models.ListAccessTokensResponse response from the API call.</returns>
+        public Models.ListAccessTokensResponse DeleteAccessTokens(
+                string customerId)
         {
-            Task<Models.ListCustomersResponse> t = this.GetCustomersAsync(name, document, page, size, email, code);
+            Task<Models.ListAccessTokensResponse> t = this.DeleteAccessTokensAsync(customerId);
             ApiHelper.RunTaskSynchronously(t);
             return t.Result;
         }
 
         /// <summary>
-        /// Get all Customers.
+        /// Delete a Customer's access tokens.
         /// </summary>
-        /// <param name="name">Optional parameter: Name of the Customer.</param>
-        /// <param name="document">Optional parameter: Document of the Customer.</param>
-        /// <param name="page">Optional parameter: Current page the the search.</param>
-        /// <param name="size">Optional parameter: Quantity pages of the search.</param>
-        /// <param name="email">Optional parameter: Customer's email.</param>
-        /// <param name="code">Optional parameter: Customer's code.</param>
+        /// <param name="customerId">Required parameter: Customer Id.</param>
         /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.ListCustomersResponse response from the API call.</returns>
-        public async Task<Models.ListCustomersResponse> GetCustomersAsync(
-                string name = null,
-                string document = null,
-                int? page = 1,
-                int? size = 10,
-                string email = null,
-                string code = null,
+        /// <returns>Returns the Models.ListAccessTokensResponse response from the API call.</returns>
+        public async Task<Models.ListAccessTokensResponse> DeleteAccessTokensAsync(
+                string customerId,
                 CancellationToken cancellationToken = default)
         {
             // the base uri for api requests.
@@ -696,78 +956,7 @@ namespace PagarmeApiSDK.Standard.Controllers
 
             // prepare query string for API call.
             StringBuilder queryBuilder = new StringBuilder(baseUri);
-            queryBuilder.Append("/customers");
-
-            // prepare specfied query parameters.
-            var queryParams = new Dictionary<string, object>()
-            {
-                { "name", name },
-                { "document", document },
-                { "page", (page != null) ? page : 1 },
-                { "size", (size != null) ? size : 10 },
-                { "email", email },
-                { "Code", code },
-            };
-
-            // append request with appropriate headers and parameters
-            var headers = new Dictionary<string, string>()
-            {
-                { "user-agent", this.UserAgent },
-                { "accept", "application/json" },
-            };
-
-            // prepare the API call request to fetch the response.
-            HttpRequest httpRequest = this.GetClientInstance().Get(queryBuilder.ToString(), headers, queryParameters: queryParams);
-
-            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
-
-            // invoke request and get response.
-            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
-            HttpContext context = new HttpContext(httpRequest, response);
-
-            // handle errors defined at the API level.
-            this.ValidateResponse(response, context);
-
-            return ApiHelper.JsonDeserialize<Models.ListCustomersResponse>(response.Body);
-        }
-
-        /// <summary>
-        /// Updates a customer.
-        /// </summary>
-        /// <param name="customerId">Required parameter: Customer id.</param>
-        /// <param name="request">Required parameter: Request for updating a customer.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <returns>Returns the Models.GetCustomerResponse response from the API call.</returns>
-        public Models.GetCustomerResponse UpdateCustomer(
-                string customerId,
-                Models.UpdateCustomerRequest request,
-                string idempotencyKey = null)
-        {
-            Task<Models.GetCustomerResponse> t = this.UpdateCustomerAsync(customerId, request, idempotencyKey);
-            ApiHelper.RunTaskSynchronously(t);
-            return t.Result;
-        }
-
-        /// <summary>
-        /// Updates a customer.
-        /// </summary>
-        /// <param name="customerId">Required parameter: Customer id.</param>
-        /// <param name="request">Required parameter: Request for updating a customer.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetCustomerResponse response from the API call.</returns>
-        public async Task<Models.GetCustomerResponse> UpdateCustomerAsync(
-                string customerId,
-                Models.UpdateCustomerRequest request,
-                string idempotencyKey = null,
-                CancellationToken cancellationToken = default)
-        {
-            // the base uri for api requests.
-            string baseUri = this.Config.GetBaseUri();
-
-            // prepare query string for API call.
-            StringBuilder queryBuilder = new StringBuilder(baseUri);
-            queryBuilder.Append("/customers/{customer_id}");
+            queryBuilder.Append("/customers/{customer_id}/access-tokens/");
 
             // process optional template parameters.
             ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
@@ -780,15 +969,10 @@ namespace PagarmeApiSDK.Standard.Controllers
             {
                 { "user-agent", this.UserAgent },
                 { "accept", "application/json" },
-                { "content-type", "application/json; charset=utf-8" },
-                { "idempotency-key", idempotencyKey },
             };
 
-            // append body params.
-            var bodyText = ApiHelper.JsonSerialize(request);
-
             // prepare the API call request to fetch the response.
-            HttpRequest httpRequest = this.GetClientInstance().PutBody(queryBuilder.ToString(), headers, bodyText);
+            HttpRequest httpRequest = this.GetClientInstance().Get(queryBuilder.ToString(), headers);
 
             httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
 
@@ -799,7 +983,7 @@ namespace PagarmeApiSDK.Standard.Controllers
             // handle errors defined at the API level.
             this.ValidateResponse(response, context);
 
-            return ApiHelper.JsonDeserialize<Models.GetCustomerResponse>(response.Body);
+            return ApiHelper.JsonDeserialize<Models.ListAccessTokensResponse>(response.Body);
         }
 
         /// <summary>
@@ -947,34 +1131,46 @@ namespace PagarmeApiSDK.Standard.Controllers
         }
 
         /// <summary>
-        /// Get all cards from a customer.
+        /// Get all Customers.
         /// </summary>
-        /// <param name="customerId">Required parameter: Customer Id.</param>
-        /// <param name="page">Optional parameter: Page number.</param>
-        /// <param name="size">Optional parameter: Page size.</param>
-        /// <returns>Returns the Models.ListCardsResponse response from the API call.</returns>
-        public Models.ListCardsResponse GetCards(
-                string customerId,
-                int? page = null,
-                int? size = null)
+        /// <param name="name">Optional parameter: Name of the Customer.</param>
+        /// <param name="document">Optional parameter: Document of the Customer.</param>
+        /// <param name="page">Optional parameter: Current page the the search.</param>
+        /// <param name="size">Optional parameter: Quantity pages of the search.</param>
+        /// <param name="email">Optional parameter: Customer's email.</param>
+        /// <param name="code">Optional parameter: Customer's code.</param>
+        /// <returns>Returns the Models.ListCustomersResponse response from the API call.</returns>
+        public Models.ListCustomersResponse GetCustomers(
+                string name = null,
+                string document = null,
+                int? page = 1,
+                int? size = 10,
+                string email = null,
+                string code = null)
         {
-            Task<Models.ListCardsResponse> t = this.GetCardsAsync(customerId, page, size);
+            Task<Models.ListCustomersResponse> t = this.GetCustomersAsync(name, document, page, size, email, code);
             ApiHelper.RunTaskSynchronously(t);
             return t.Result;
         }
 
         /// <summary>
-        /// Get all cards from a customer.
+        /// Get all Customers.
         /// </summary>
-        /// <param name="customerId">Required parameter: Customer Id.</param>
-        /// <param name="page">Optional parameter: Page number.</param>
-        /// <param name="size">Optional parameter: Page size.</param>
+        /// <param name="name">Optional parameter: Name of the Customer.</param>
+        /// <param name="document">Optional parameter: Document of the Customer.</param>
+        /// <param name="page">Optional parameter: Current page the the search.</param>
+        /// <param name="size">Optional parameter: Quantity pages of the search.</param>
+        /// <param name="email">Optional parameter: Customer's email.</param>
+        /// <param name="code">Optional parameter: Customer's code.</param>
         /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.ListCardsResponse response from the API call.</returns>
-        public async Task<Models.ListCardsResponse> GetCardsAsync(
-                string customerId,
-                int? page = null,
-                int? size = null,
+        /// <returns>Returns the Models.ListCustomersResponse response from the API call.</returns>
+        public async Task<Models.ListCustomersResponse> GetCustomersAsync(
+                string name = null,
+                string document = null,
+                int? page = 1,
+                int? size = 10,
+                string email = null,
+                string code = null,
                 CancellationToken cancellationToken = default)
         {
             // the base uri for api requests.
@@ -982,19 +1178,17 @@ namespace PagarmeApiSDK.Standard.Controllers
 
             // prepare query string for API call.
             StringBuilder queryBuilder = new StringBuilder(baseUri);
-            queryBuilder.Append("/customers/{customer_id}/cards");
-
-            // process optional template parameters.
-            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
-            {
-                { "customer_id", customerId },
-            });
+            queryBuilder.Append("/customers");
 
             // prepare specfied query parameters.
             var queryParams = new Dictionary<string, object>()
             {
-                { "page", page },
-                { "size", size },
+                { "name", name },
+                { "document", document },
+                { "page", (page != null) ? page : 1 },
+                { "size", (size != null) ? size : 10 },
+                { "email", email },
+                { "Code", code },
             };
 
             // append request with appropriate headers and parameters
@@ -1016,37 +1210,37 @@ namespace PagarmeApiSDK.Standard.Controllers
             // handle errors defined at the API level.
             this.ValidateResponse(response, context);
 
-            return ApiHelper.JsonDeserialize<Models.ListCardsResponse>(response.Body);
+            return ApiHelper.JsonDeserialize<Models.ListCustomersResponse>(response.Body);
         }
 
         /// <summary>
-        /// Renew a card.
+        /// Updates a customer.
         /// </summary>
         /// <param name="customerId">Required parameter: Customer id.</param>
-        /// <param name="cardId">Required parameter: Card Id.</param>
+        /// <param name="request">Required parameter: Request for updating a customer.</param>
         /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <returns>Returns the Models.GetCardResponse response from the API call.</returns>
-        public Models.GetCardResponse RenewCard(
+        /// <returns>Returns the Models.GetCustomerResponse response from the API call.</returns>
+        public Models.GetCustomerResponse UpdateCustomer(
                 string customerId,
-                string cardId,
+                Models.UpdateCustomerRequest request,
                 string idempotencyKey = null)
         {
-            Task<Models.GetCardResponse> t = this.RenewCardAsync(customerId, cardId, idempotencyKey);
+            Task<Models.GetCustomerResponse> t = this.UpdateCustomerAsync(customerId, request, idempotencyKey);
             ApiHelper.RunTaskSynchronously(t);
             return t.Result;
         }
 
         /// <summary>
-        /// Renew a card.
+        /// Updates a customer.
         /// </summary>
         /// <param name="customerId">Required parameter: Customer id.</param>
-        /// <param name="cardId">Required parameter: Card Id.</param>
+        /// <param name="request">Required parameter: Request for updating a customer.</param>
         /// <param name="idempotencyKey">Optional parameter: Example: .</param>
         /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetCardResponse response from the API call.</returns>
-        public async Task<Models.GetCardResponse> RenewCardAsync(
+        /// <returns>Returns the Models.GetCustomerResponse response from the API call.</returns>
+        public async Task<Models.GetCustomerResponse> UpdateCustomerAsync(
                 string customerId,
-                string cardId,
+                Models.UpdateCustomerRequest request,
                 string idempotencyKey = null,
                 CancellationToken cancellationToken = default)
         {
@@ -1055,138 +1249,7 @@ namespace PagarmeApiSDK.Standard.Controllers
 
             // prepare query string for API call.
             StringBuilder queryBuilder = new StringBuilder(baseUri);
-            queryBuilder.Append("/customers/{customer_id}/cards/{card_id}/renew");
-
-            // process optional template parameters.
-            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
-            {
-                { "customer_id", customerId },
-                { "card_id", cardId },
-            });
-
-            // append request with appropriate headers and parameters
-            var headers = new Dictionary<string, string>()
-            {
-                { "user-agent", this.UserAgent },
-                { "accept", "application/json" },
-                { "idempotency-key", idempotencyKey },
-            };
-
-            // prepare the API call request to fetch the response.
-            HttpRequest httpRequest = this.GetClientInstance().Post(queryBuilder.ToString(), headers, null);
-
-            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
-
-            // invoke request and get response.
-            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
-            HttpContext context = new HttpContext(httpRequest, response);
-
-            // handle errors defined at the API level.
-            this.ValidateResponse(response, context);
-
-            return ApiHelper.JsonDeserialize<Models.GetCardResponse>(response.Body);
-        }
-
-        /// <summary>
-        /// Get a Customer's access token.
-        /// </summary>
-        /// <param name="customerId">Required parameter: Customer Id.</param>
-        /// <param name="tokenId">Required parameter: Token Id.</param>
-        /// <returns>Returns the Models.GetAccessTokenResponse response from the API call.</returns>
-        public Models.GetAccessTokenResponse GetAccessToken(
-                string customerId,
-                string tokenId)
-        {
-            Task<Models.GetAccessTokenResponse> t = this.GetAccessTokenAsync(customerId, tokenId);
-            ApiHelper.RunTaskSynchronously(t);
-            return t.Result;
-        }
-
-        /// <summary>
-        /// Get a Customer's access token.
-        /// </summary>
-        /// <param name="customerId">Required parameter: Customer Id.</param>
-        /// <param name="tokenId">Required parameter: Token Id.</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetAccessTokenResponse response from the API call.</returns>
-        public async Task<Models.GetAccessTokenResponse> GetAccessTokenAsync(
-                string customerId,
-                string tokenId,
-                CancellationToken cancellationToken = default)
-        {
-            // the base uri for api requests.
-            string baseUri = this.Config.GetBaseUri();
-
-            // prepare query string for API call.
-            StringBuilder queryBuilder = new StringBuilder(baseUri);
-            queryBuilder.Append("/customers/{customer_id}/access-tokens/{token_id}");
-
-            // process optional template parameters.
-            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
-            {
-                { "customer_id", customerId },
-                { "token_id", tokenId },
-            });
-
-            // append request with appropriate headers and parameters
-            var headers = new Dictionary<string, string>()
-            {
-                { "user-agent", this.UserAgent },
-                { "accept", "application/json" },
-            };
-
-            // prepare the API call request to fetch the response.
-            HttpRequest httpRequest = this.GetClientInstance().Get(queryBuilder.ToString(), headers);
-
-            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
-
-            // invoke request and get response.
-            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
-            HttpContext context = new HttpContext(httpRequest, response);
-
-            // handle errors defined at the API level.
-            this.ValidateResponse(response, context);
-
-            return ApiHelper.JsonDeserialize<Models.GetAccessTokenResponse>(response.Body);
-        }
-
-        /// <summary>
-        /// Updates the metadata a customer.
-        /// </summary>
-        /// <param name="customerId">Required parameter: The customer id.</param>
-        /// <param name="request">Required parameter: Request for updating the customer metadata.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <returns>Returns the Models.GetCustomerResponse response from the API call.</returns>
-        public Models.GetCustomerResponse UpdateCustomerMetadata(
-                string customerId,
-                Models.UpdateMetadataRequest request,
-                string idempotencyKey = null)
-        {
-            Task<Models.GetCustomerResponse> t = this.UpdateCustomerMetadataAsync(customerId, request, idempotencyKey);
-            ApiHelper.RunTaskSynchronously(t);
-            return t.Result;
-        }
-
-        /// <summary>
-        /// Updates the metadata a customer.
-        /// </summary>
-        /// <param name="customerId">Required parameter: The customer id.</param>
-        /// <param name="request">Required parameter: Request for updating the customer metadata.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetCustomerResponse response from the API call.</returns>
-        public async Task<Models.GetCustomerResponse> UpdateCustomerMetadataAsync(
-                string customerId,
-                Models.UpdateMetadataRequest request,
-                string idempotencyKey = null,
-                CancellationToken cancellationToken = default)
-        {
-            // the base uri for api requests.
-            string baseUri = this.Config.GetBaseUri();
-
-            // prepare query string for API call.
-            StringBuilder queryBuilder = new StringBuilder(baseUri);
-            queryBuilder.Append("/Customers/{customer_id}/metadata");
+            queryBuilder.Append("/customers/{customer_id}");
 
             // process optional template parameters.
             ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
@@ -1207,7 +1270,7 @@ namespace PagarmeApiSDK.Standard.Controllers
             var bodyText = ApiHelper.JsonSerialize(request);
 
             // prepare the API call request to fetch the response.
-            HttpRequest httpRequest = this.GetClientInstance().PatchBody(queryBuilder.ToString(), headers, bodyText);
+            HttpRequest httpRequest = this.GetClientInstance().PutBody(queryBuilder.ToString(), headers, bodyText);
 
             httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
 
@@ -1418,69 +1481,6 @@ namespace PagarmeApiSDK.Standard.Controllers
             this.ValidateResponse(response, context);
 
             return ApiHelper.JsonDeserialize<Models.GetCustomerResponse>(response.Body);
-        }
-
-        /// <summary>
-        /// Get a customer's card.
-        /// </summary>
-        /// <param name="customerId">Required parameter: Customer id.</param>
-        /// <param name="cardId">Required parameter: Card id.</param>
-        /// <returns>Returns the Models.GetCardResponse response from the API call.</returns>
-        public Models.GetCardResponse GetCard(
-                string customerId,
-                string cardId)
-        {
-            Task<Models.GetCardResponse> t = this.GetCardAsync(customerId, cardId);
-            ApiHelper.RunTaskSynchronously(t);
-            return t.Result;
-        }
-
-        /// <summary>
-        /// Get a customer's card.
-        /// </summary>
-        /// <param name="customerId">Required parameter: Customer id.</param>
-        /// <param name="cardId">Required parameter: Card id.</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetCardResponse response from the API call.</returns>
-        public async Task<Models.GetCardResponse> GetCardAsync(
-                string customerId,
-                string cardId,
-                CancellationToken cancellationToken = default)
-        {
-            // the base uri for api requests.
-            string baseUri = this.Config.GetBaseUri();
-
-            // prepare query string for API call.
-            StringBuilder queryBuilder = new StringBuilder(baseUri);
-            queryBuilder.Append("/customers/{customer_id}/cards/{card_id}");
-
-            // process optional template parameters.
-            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
-            {
-                { "customer_id", customerId },
-                { "card_id", cardId },
-            });
-
-            // append request with appropriate headers and parameters
-            var headers = new Dictionary<string, string>()
-            {
-                { "user-agent", this.UserAgent },
-                { "accept", "application/json" },
-            };
-
-            // prepare the API call request to fetch the response.
-            HttpRequest httpRequest = this.GetClientInstance().Get(queryBuilder.ToString(), headers);
-
-            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
-
-            // invoke request and get response.
-            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
-            HttpContext context = new HttpContext(httpRequest, response);
-
-            // handle errors defined at the API level.
-            this.ValidateResponse(response, context);
-
-            return ApiHelper.JsonDeserialize<Models.GetCardResponse>(response.Body);
         }
     }
 }

--- a/PagarmeApiSDK.Standard/Controllers/IChargesController.cs
+++ b/PagarmeApiSDK.Standard/Controllers/IChargesController.cs
@@ -75,6 +75,80 @@ namespace PagarmeApiSDK.Standard.Controllers
                 CancellationToken cancellationToken = default);
 
         /// <summary>
+        /// Updates the card from a charge.
+        /// </summary>
+        /// <param name="chargeId">Required parameter: Charge id.</param>
+        /// <param name="request">Required parameter: Request for updating a charge's card.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <returns>Returns the Models.GetChargeResponse response from the API call.</returns>
+        Models.GetChargeResponse UpdateChargeCard(
+                string chargeId,
+                Models.UpdateChargeCardRequest request,
+                string idempotencyKey = null);
+
+        /// <summary>
+        /// Updates the card from a charge.
+        /// </summary>
+        /// <param name="chargeId">Required parameter: Charge id.</param>
+        /// <param name="request">Required parameter: Request for updating a charge's card.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetChargeResponse response from the API call.</returns>
+        Task<Models.GetChargeResponse> UpdateChargeCardAsync(
+                string chargeId,
+                Models.UpdateChargeCardRequest request,
+                string idempotencyKey = null,
+                CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// GetChargesSummary EndPoint.
+        /// </summary>
+        /// <param name="status">Required parameter: Example: .</param>
+        /// <param name="createdSince">Optional parameter: Example: .</param>
+        /// <param name="createdUntil">Optional parameter: Example: .</param>
+        /// <returns>Returns the Models.GetChargesSummaryResponse response from the API call.</returns>
+        Models.GetChargesSummaryResponse GetChargesSummary(
+                string status,
+                DateTime? createdSince = null,
+                DateTime? createdUntil = null);
+
+        /// <summary>
+        /// GetChargesSummary EndPoint.
+        /// </summary>
+        /// <param name="status">Required parameter: Example: .</param>
+        /// <param name="createdSince">Optional parameter: Example: .</param>
+        /// <param name="createdUntil">Optional parameter: Example: .</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetChargesSummaryResponse response from the API call.</returns>
+        Task<Models.GetChargesSummaryResponse> GetChargesSummaryAsync(
+                string status,
+                DateTime? createdSince = null,
+                DateTime? createdUntil = null,
+                CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Creates a new charge.
+        /// </summary>
+        /// <param name="request">Required parameter: Request for creating a charge.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <returns>Returns the Models.GetChargeResponse response from the API call.</returns>
+        Models.GetChargeResponse CreateCharge(
+                Models.CreateChargeRequest request,
+                string idempotencyKey = null);
+
+        /// <summary>
+        /// Creates a new charge.
+        /// </summary>
+        /// <param name="request">Required parameter: Request for creating a charge.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetChargeResponse response from the API call.</returns>
+        Task<Models.GetChargeResponse> CreateChargeAsync(
+                Models.CreateChargeRequest request,
+                string idempotencyKey = null,
+                CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// GetChargeTransactions EndPoint.
         /// </summary>
         /// <param name="chargeId">Required parameter: Charge Id.</param>
@@ -101,28 +175,72 @@ namespace PagarmeApiSDK.Standard.Controllers
                 CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Updates the due date from a charge.
+        /// Captures a charge.
         /// </summary>
-        /// <param name="chargeId">Required parameter: Charge Id.</param>
-        /// <param name="request">Required parameter: Request for updating the due date.</param>
+        /// <param name="chargeId">Required parameter: Charge id.</param>
+        /// <param name="request">Optional parameter: Request for capturing a charge.</param>
         /// <param name="idempotencyKey">Optional parameter: Example: .</param>
         /// <returns>Returns the Models.GetChargeResponse response from the API call.</returns>
-        Models.GetChargeResponse UpdateChargeDueDate(
+        Models.GetChargeResponse CaptureCharge(
                 string chargeId,
-                Models.UpdateChargeDueDateRequest request,
+                Models.CreateCaptureChargeRequest request = null,
                 string idempotencyKey = null);
 
         /// <summary>
-        /// Updates the due date from a charge.
+        /// Captures a charge.
         /// </summary>
-        /// <param name="chargeId">Required parameter: Charge Id.</param>
-        /// <param name="request">Required parameter: Request for updating the due date.</param>
+        /// <param name="chargeId">Required parameter: Charge id.</param>
+        /// <param name="request">Optional parameter: Request for capturing a charge.</param>
         /// <param name="idempotencyKey">Optional parameter: Example: .</param>
         /// <param name="cancellationToken"> cancellationToken. </param>
         /// <returns>Returns the Models.GetChargeResponse response from the API call.</returns>
-        Task<Models.GetChargeResponse> UpdateChargeDueDateAsync(
+        Task<Models.GetChargeResponse> CaptureChargeAsync(
                 string chargeId,
-                Models.UpdateChargeDueDateRequest request,
+                Models.CreateCaptureChargeRequest request = null,
+                string idempotencyKey = null,
+                CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Get a charge from its id.
+        /// </summary>
+        /// <param name="chargeId">Required parameter: Charge id.</param>
+        /// <returns>Returns the Models.GetChargeResponse response from the API call.</returns>
+        Models.GetChargeResponse GetCharge(
+                string chargeId);
+
+        /// <summary>
+        /// Get a charge from its id.
+        /// </summary>
+        /// <param name="chargeId">Required parameter: Charge id.</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetChargeResponse response from the API call.</returns>
+        Task<Models.GetChargeResponse> GetChargeAsync(
+                string chargeId,
+                CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Cancel a charge.
+        /// </summary>
+        /// <param name="chargeId">Required parameter: Charge id.</param>
+        /// <param name="request">Optional parameter: Request for cancelling a charge.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <returns>Returns the Models.GetChargeResponse response from the API call.</returns>
+        Models.GetChargeResponse CancelCharge(
+                string chargeId,
+                Models.CreateCancelChargeRequest request = null,
+                string idempotencyKey = null);
+
+        /// <summary>
+        /// Cancel a charge.
+        /// </summary>
+        /// <param name="chargeId">Required parameter: Charge id.</param>
+        /// <param name="request">Optional parameter: Request for cancelling a charge.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetChargeResponse response from the API call.</returns>
+        Task<Models.GetChargeResponse> CancelChargeAsync(
+                string chargeId,
+                Models.CreateCancelChargeRequest request = null,
                 string idempotencyKey = null,
                 CancellationToken cancellationToken = default);
 
@@ -177,172 +295,6 @@ namespace PagarmeApiSDK.Standard.Controllers
                 CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Captures a charge.
-        /// </summary>
-        /// <param name="chargeId">Required parameter: Charge id.</param>
-        /// <param name="request">Optional parameter: Request for capturing a charge.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <returns>Returns the Models.GetChargeResponse response from the API call.</returns>
-        Models.GetChargeResponse CaptureCharge(
-                string chargeId,
-                Models.CreateCaptureChargeRequest request = null,
-                string idempotencyKey = null);
-
-        /// <summary>
-        /// Captures a charge.
-        /// </summary>
-        /// <param name="chargeId">Required parameter: Charge id.</param>
-        /// <param name="request">Optional parameter: Request for capturing a charge.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetChargeResponse response from the API call.</returns>
-        Task<Models.GetChargeResponse> CaptureChargeAsync(
-                string chargeId,
-                Models.CreateCaptureChargeRequest request = null,
-                string idempotencyKey = null,
-                CancellationToken cancellationToken = default);
-
-        /// <summary>
-        /// Updates the card from a charge.
-        /// </summary>
-        /// <param name="chargeId">Required parameter: Charge id.</param>
-        /// <param name="request">Required parameter: Request for updating a charge's card.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <returns>Returns the Models.GetChargeResponse response from the API call.</returns>
-        Models.GetChargeResponse UpdateChargeCard(
-                string chargeId,
-                Models.UpdateChargeCardRequest request,
-                string idempotencyKey = null);
-
-        /// <summary>
-        /// Updates the card from a charge.
-        /// </summary>
-        /// <param name="chargeId">Required parameter: Charge id.</param>
-        /// <param name="request">Required parameter: Request for updating a charge's card.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetChargeResponse response from the API call.</returns>
-        Task<Models.GetChargeResponse> UpdateChargeCardAsync(
-                string chargeId,
-                Models.UpdateChargeCardRequest request,
-                string idempotencyKey = null,
-                CancellationToken cancellationToken = default);
-
-        /// <summary>
-        /// Get a charge from its id.
-        /// </summary>
-        /// <param name="chargeId">Required parameter: Charge id.</param>
-        /// <returns>Returns the Models.GetChargeResponse response from the API call.</returns>
-        Models.GetChargeResponse GetCharge(
-                string chargeId);
-
-        /// <summary>
-        /// Get a charge from its id.
-        /// </summary>
-        /// <param name="chargeId">Required parameter: Charge id.</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetChargeResponse response from the API call.</returns>
-        Task<Models.GetChargeResponse> GetChargeAsync(
-                string chargeId,
-                CancellationToken cancellationToken = default);
-
-        /// <summary>
-        /// GetChargesSummary EndPoint.
-        /// </summary>
-        /// <param name="status">Required parameter: Example: .</param>
-        /// <param name="createdSince">Optional parameter: Example: .</param>
-        /// <param name="createdUntil">Optional parameter: Example: .</param>
-        /// <returns>Returns the Models.GetChargesSummaryResponse response from the API call.</returns>
-        Models.GetChargesSummaryResponse GetChargesSummary(
-                string status,
-                DateTime? createdSince = null,
-                DateTime? createdUntil = null);
-
-        /// <summary>
-        /// GetChargesSummary EndPoint.
-        /// </summary>
-        /// <param name="status">Required parameter: Example: .</param>
-        /// <param name="createdSince">Optional parameter: Example: .</param>
-        /// <param name="createdUntil">Optional parameter: Example: .</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetChargesSummaryResponse response from the API call.</returns>
-        Task<Models.GetChargesSummaryResponse> GetChargesSummaryAsync(
-                string status,
-                DateTime? createdSince = null,
-                DateTime? createdUntil = null,
-                CancellationToken cancellationToken = default);
-
-        /// <summary>
-        /// Retries a charge.
-        /// </summary>
-        /// <param name="chargeId">Required parameter: Charge id.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <returns>Returns the Models.GetChargeResponse response from the API call.</returns>
-        Models.GetChargeResponse RetryCharge(
-                string chargeId,
-                string idempotencyKey = null);
-
-        /// <summary>
-        /// Retries a charge.
-        /// </summary>
-        /// <param name="chargeId">Required parameter: Charge id.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetChargeResponse response from the API call.</returns>
-        Task<Models.GetChargeResponse> RetryChargeAsync(
-                string chargeId,
-                string idempotencyKey = null,
-                CancellationToken cancellationToken = default);
-
-        /// <summary>
-        /// Cancel a charge.
-        /// </summary>
-        /// <param name="chargeId">Required parameter: Charge id.</param>
-        /// <param name="request">Optional parameter: Request for cancelling a charge.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <returns>Returns the Models.GetChargeResponse response from the API call.</returns>
-        Models.GetChargeResponse CancelCharge(
-                string chargeId,
-                Models.CreateCancelChargeRequest request = null,
-                string idempotencyKey = null);
-
-        /// <summary>
-        /// Cancel a charge.
-        /// </summary>
-        /// <param name="chargeId">Required parameter: Charge id.</param>
-        /// <param name="request">Optional parameter: Request for cancelling a charge.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetChargeResponse response from the API call.</returns>
-        Task<Models.GetChargeResponse> CancelChargeAsync(
-                string chargeId,
-                Models.CreateCancelChargeRequest request = null,
-                string idempotencyKey = null,
-                CancellationToken cancellationToken = default);
-
-        /// <summary>
-        /// Creates a new charge.
-        /// </summary>
-        /// <param name="request">Required parameter: Request for creating a charge.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <returns>Returns the Models.GetChargeResponse response from the API call.</returns>
-        Models.GetChargeResponse CreateCharge(
-                Models.CreateChargeRequest request,
-                string idempotencyKey = null);
-
-        /// <summary>
-        /// Creates a new charge.
-        /// </summary>
-        /// <param name="request">Required parameter: Request for creating a charge.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetChargeResponse response from the API call.</returns>
-        Task<Models.GetChargeResponse> CreateChargeAsync(
-                Models.CreateChargeRequest request,
-                string idempotencyKey = null,
-                CancellationToken cancellationToken = default);
-
-        /// <summary>
         /// ConfirmPayment EndPoint.
         /// </summary>
         /// <param name="chargeId">Required parameter: Example: .</param>
@@ -365,6 +317,54 @@ namespace PagarmeApiSDK.Standard.Controllers
         Task<Models.GetChargeResponse> ConfirmPaymentAsync(
                 string chargeId,
                 Models.CreateConfirmPaymentRequest request = null,
+                string idempotencyKey = null,
+                CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Updates the due date from a charge.
+        /// </summary>
+        /// <param name="chargeId">Required parameter: Charge Id.</param>
+        /// <param name="request">Required parameter: Request for updating the due date.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <returns>Returns the Models.GetChargeResponse response from the API call.</returns>
+        Models.GetChargeResponse UpdateChargeDueDate(
+                string chargeId,
+                Models.UpdateChargeDueDateRequest request,
+                string idempotencyKey = null);
+
+        /// <summary>
+        /// Updates the due date from a charge.
+        /// </summary>
+        /// <param name="chargeId">Required parameter: Charge Id.</param>
+        /// <param name="request">Required parameter: Request for updating the due date.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetChargeResponse response from the API call.</returns>
+        Task<Models.GetChargeResponse> UpdateChargeDueDateAsync(
+                string chargeId,
+                Models.UpdateChargeDueDateRequest request,
+                string idempotencyKey = null,
+                CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Retries a charge.
+        /// </summary>
+        /// <param name="chargeId">Required parameter: Charge id.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <returns>Returns the Models.GetChargeResponse response from the API call.</returns>
+        Models.GetChargeResponse RetryCharge(
+                string chargeId,
+                string idempotencyKey = null);
+
+        /// <summary>
+        /// Retries a charge.
+        /// </summary>
+        /// <param name="chargeId">Required parameter: Charge id.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetChargeResponse response from the API call.</returns>
+        Task<Models.GetChargeResponse> RetryChargeAsync(
+                string chargeId,
                 string idempotencyKey = null,
                 CancellationToken cancellationToken = default);
     }

--- a/PagarmeApiSDK.Standard/Controllers/ICustomersController.cs
+++ b/PagarmeApiSDK.Standard/Controllers/ICustomersController.cs
@@ -109,28 +109,6 @@ namespace PagarmeApiSDK.Standard.Controllers
                 CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Creates a new customer.
-        /// </summary>
-        /// <param name="request">Required parameter: Request for creating a customer.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <returns>Returns the Models.GetCustomerResponse response from the API call.</returns>
-        Models.GetCustomerResponse CreateCustomer(
-                Models.CreateCustomerRequest request,
-                string idempotencyKey = null);
-
-        /// <summary>
-        /// Creates a new customer.
-        /// </summary>
-        /// <param name="request">Required parameter: Request for creating a customer.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetCustomerResponse response from the API call.</returns>
-        Task<Models.GetCustomerResponse> CreateCustomerAsync(
-                Models.CreateCustomerRequest request,
-                string idempotencyKey = null,
-                CancellationToken cancellationToken = default);
-
-        /// <summary>
         /// Creates a new address for a customer.
         /// </summary>
         /// <param name="customerId">Required parameter: Customer Id.</param>
@@ -157,21 +135,103 @@ namespace PagarmeApiSDK.Standard.Controllers
                 CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Delete a Customer's access tokens.
+        /// Creates a new customer.
         /// </summary>
-        /// <param name="customerId">Required parameter: Customer Id.</param>
-        /// <returns>Returns the Models.ListAccessTokensResponse response from the API call.</returns>
-        Models.ListAccessTokensResponse DeleteAccessTokens(
-                string customerId);
+        /// <param name="request">Required parameter: Request for creating a customer.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <returns>Returns the Models.GetCustomerResponse response from the API call.</returns>
+        Models.GetCustomerResponse CreateCustomer(
+                Models.CreateCustomerRequest request,
+                string idempotencyKey = null);
 
         /// <summary>
-        /// Delete a Customer's access tokens.
+        /// Creates a new customer.
+        /// </summary>
+        /// <param name="request">Required parameter: Request for creating a customer.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetCustomerResponse response from the API call.</returns>
+        Task<Models.GetCustomerResponse> CreateCustomerAsync(
+                Models.CreateCustomerRequest request,
+                string idempotencyKey = null,
+                CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Creates a new card for a customer.
+        /// </summary>
+        /// <param name="customerId">Required parameter: Customer id.</param>
+        /// <param name="request">Required parameter: Request for creating a card.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <returns>Returns the Models.GetCardResponse response from the API call.</returns>
+        Models.GetCardResponse CreateCard(
+                string customerId,
+                Models.CreateCardRequest request,
+                string idempotencyKey = null);
+
+        /// <summary>
+        /// Creates a new card for a customer.
+        /// </summary>
+        /// <param name="customerId">Required parameter: Customer id.</param>
+        /// <param name="request">Required parameter: Request for creating a card.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetCardResponse response from the API call.</returns>
+        Task<Models.GetCardResponse> CreateCardAsync(
+                string customerId,
+                Models.CreateCardRequest request,
+                string idempotencyKey = null,
+                CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Get all cards from a customer.
         /// </summary>
         /// <param name="customerId">Required parameter: Customer Id.</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.ListAccessTokensResponse response from the API call.</returns>
-        Task<Models.ListAccessTokensResponse> DeleteAccessTokensAsync(
+        /// <param name="page">Optional parameter: Page number.</param>
+        /// <param name="size">Optional parameter: Page size.</param>
+        /// <returns>Returns the Models.ListCardsResponse response from the API call.</returns>
+        Models.ListCardsResponse GetCards(
                 string customerId,
+                int? page = null,
+                int? size = null);
+
+        /// <summary>
+        /// Get all cards from a customer.
+        /// </summary>
+        /// <param name="customerId">Required parameter: Customer Id.</param>
+        /// <param name="page">Optional parameter: Page number.</param>
+        /// <param name="size">Optional parameter: Page size.</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.ListCardsResponse response from the API call.</returns>
+        Task<Models.ListCardsResponse> GetCardsAsync(
+                string customerId,
+                int? page = null,
+                int? size = null,
+                CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Renew a card.
+        /// </summary>
+        /// <param name="customerId">Required parameter: Customer id.</param>
+        /// <param name="cardId">Required parameter: Card Id.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <returns>Returns the Models.GetCardResponse response from the API call.</returns>
+        Models.GetCardResponse RenewCard(
+                string customerId,
+                string cardId,
+                string idempotencyKey = null);
+
+        /// <summary>
+        /// Renew a card.
+        /// </summary>
+        /// <param name="customerId">Required parameter: Customer id.</param>
+        /// <param name="cardId">Required parameter: Card Id.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetCardResponse response from the API call.</returns>
+        Task<Models.GetCardResponse> RenewCardAsync(
+                string customerId,
+                string cardId,
+                string idempotencyKey = null,
                 CancellationToken cancellationToken = default);
 
         /// <summary>
@@ -223,29 +283,143 @@ namespace PagarmeApiSDK.Standard.Controllers
                 CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Creates a new card for a customer.
+        /// Get a Customer's access token.
         /// </summary>
-        /// <param name="customerId">Required parameter: Customer id.</param>
-        /// <param name="request">Required parameter: Request for creating a card.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <returns>Returns the Models.GetCardResponse response from the API call.</returns>
-        Models.GetCardResponse CreateCard(
+        /// <param name="customerId">Required parameter: Customer Id.</param>
+        /// <param name="tokenId">Required parameter: Token Id.</param>
+        /// <returns>Returns the Models.GetAccessTokenResponse response from the API call.</returns>
+        Models.GetAccessTokenResponse GetAccessToken(
                 string customerId,
-                Models.CreateCardRequest request,
+                string tokenId);
+
+        /// <summary>
+        /// Get a Customer's access token.
+        /// </summary>
+        /// <param name="customerId">Required parameter: Customer Id.</param>
+        /// <param name="tokenId">Required parameter: Token Id.</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetAccessTokenResponse response from the API call.</returns>
+        Task<Models.GetAccessTokenResponse> GetAccessTokenAsync(
+                string customerId,
+                string tokenId,
+                CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Updates the metadata a customer.
+        /// </summary>
+        /// <param name="customerId">Required parameter: The customer id.</param>
+        /// <param name="request">Required parameter: Request for updating the customer metadata.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <returns>Returns the Models.GetCustomerResponse response from the API call.</returns>
+        Models.GetCustomerResponse UpdateCustomerMetadata(
+                string customerId,
+                Models.UpdateMetadataRequest request,
                 string idempotencyKey = null);
 
         /// <summary>
-        /// Creates a new card for a customer.
+        /// Updates the metadata a customer.
         /// </summary>
-        /// <param name="customerId">Required parameter: Customer id.</param>
-        /// <param name="request">Required parameter: Request for creating a card.</param>
+        /// <param name="customerId">Required parameter: The customer id.</param>
+        /// <param name="request">Required parameter: Request for updating the customer metadata.</param>
         /// <param name="idempotencyKey">Optional parameter: Example: .</param>
         /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetCardResponse response from the API call.</returns>
-        Task<Models.GetCardResponse> CreateCardAsync(
+        /// <returns>Returns the Models.GetCustomerResponse response from the API call.</returns>
+        Task<Models.GetCustomerResponse> UpdateCustomerMetadataAsync(
                 string customerId,
-                Models.CreateCardRequest request,
+                Models.UpdateMetadataRequest request,
                 string idempotencyKey = null,
+                CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Get a customer's card.
+        /// </summary>
+        /// <param name="customerId">Required parameter: Customer id.</param>
+        /// <param name="cardId">Required parameter: Card id.</param>
+        /// <returns>Returns the Models.GetCardResponse response from the API call.</returns>
+        Models.GetCardResponse GetCard(
+                string customerId,
+                string cardId);
+
+        /// <summary>
+        /// Get a customer's card.
+        /// </summary>
+        /// <param name="customerId">Required parameter: Customer id.</param>
+        /// <param name="cardId">Required parameter: Card id.</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetCardResponse response from the API call.</returns>
+        Task<Models.GetCardResponse> GetCardAsync(
+                string customerId,
+                string cardId,
+                CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Delete a Customer's access tokens.
+        /// </summary>
+        /// <param name="customerId">Required parameter: Customer Id.</param>
+        /// <returns>Returns the Models.ListAccessTokensResponse response from the API call.</returns>
+        Models.ListAccessTokensResponse DeleteAccessTokens(
+                string customerId);
+
+        /// <summary>
+        /// Delete a Customer's access tokens.
+        /// </summary>
+        /// <param name="customerId">Required parameter: Customer Id.</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.ListAccessTokensResponse response from the API call.</returns>
+        Task<Models.ListAccessTokensResponse> DeleteAccessTokensAsync(
+                string customerId,
+                CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Creates a access token for a customer.
+        /// </summary>
+        /// <param name="customerId">Required parameter: Customer Id.</param>
+        /// <param name="request">Required parameter: Request for creating a access token.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <returns>Returns the Models.GetAccessTokenResponse response from the API call.</returns>
+        Models.GetAccessTokenResponse CreateAccessToken(
+                string customerId,
+                Models.CreateAccessTokenRequest request,
+                string idempotencyKey = null);
+
+        /// <summary>
+        /// Creates a access token for a customer.
+        /// </summary>
+        /// <param name="customerId">Required parameter: Customer Id.</param>
+        /// <param name="request">Required parameter: Request for creating a access token.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetAccessTokenResponse response from the API call.</returns>
+        Task<Models.GetAccessTokenResponse> CreateAccessTokenAsync(
+                string customerId,
+                Models.CreateAccessTokenRequest request,
+                string idempotencyKey = null,
+                CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Get all access tokens from a customer.
+        /// </summary>
+        /// <param name="customerId">Required parameter: Customer Id.</param>
+        /// <param name="page">Optional parameter: Page number.</param>
+        /// <param name="size">Optional parameter: Page size.</param>
+        /// <returns>Returns the Models.ListAccessTokensResponse response from the API call.</returns>
+        Models.ListAccessTokensResponse GetAccessTokens(
+                string customerId,
+                int? page = null,
+                int? size = null);
+
+        /// <summary>
+        /// Get all access tokens from a customer.
+        /// </summary>
+        /// <param name="customerId">Required parameter: Customer Id.</param>
+        /// <param name="page">Optional parameter: Page number.</param>
+        /// <param name="size">Optional parameter: Page size.</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.ListAccessTokensResponse response from the API call.</returns>
+        Task<Models.ListAccessTokensResponse> GetAccessTokensAsync(
+                string customerId,
+                int? page = null,
+                int? size = null,
                 CancellationToken cancellationToken = default);
 
         /// <summary>
@@ -309,158 +483,6 @@ namespace PagarmeApiSDK.Standard.Controllers
         Task<Models.GetCustomerResponse> UpdateCustomerAsync(
                 string customerId,
                 Models.UpdateCustomerRequest request,
-                string idempotencyKey = null,
-                CancellationToken cancellationToken = default);
-
-        /// <summary>
-        /// Creates a access token for a customer.
-        /// </summary>
-        /// <param name="customerId">Required parameter: Customer Id.</param>
-        /// <param name="request">Required parameter: Request for creating a access token.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <returns>Returns the Models.GetAccessTokenResponse response from the API call.</returns>
-        Models.GetAccessTokenResponse CreateAccessToken(
-                string customerId,
-                Models.CreateAccessTokenRequest request,
-                string idempotencyKey = null);
-
-        /// <summary>
-        /// Creates a access token for a customer.
-        /// </summary>
-        /// <param name="customerId">Required parameter: Customer Id.</param>
-        /// <param name="request">Required parameter: Request for creating a access token.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetAccessTokenResponse response from the API call.</returns>
-        Task<Models.GetAccessTokenResponse> CreateAccessTokenAsync(
-                string customerId,
-                Models.CreateAccessTokenRequest request,
-                string idempotencyKey = null,
-                CancellationToken cancellationToken = default);
-
-        /// <summary>
-        /// Get all access tokens from a customer.
-        /// </summary>
-        /// <param name="customerId">Required parameter: Customer Id.</param>
-        /// <param name="page">Optional parameter: Page number.</param>
-        /// <param name="size">Optional parameter: Page size.</param>
-        /// <returns>Returns the Models.ListAccessTokensResponse response from the API call.</returns>
-        Models.ListAccessTokensResponse GetAccessTokens(
-                string customerId,
-                int? page = null,
-                int? size = null);
-
-        /// <summary>
-        /// Get all access tokens from a customer.
-        /// </summary>
-        /// <param name="customerId">Required parameter: Customer Id.</param>
-        /// <param name="page">Optional parameter: Page number.</param>
-        /// <param name="size">Optional parameter: Page size.</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.ListAccessTokensResponse response from the API call.</returns>
-        Task<Models.ListAccessTokensResponse> GetAccessTokensAsync(
-                string customerId,
-                int? page = null,
-                int? size = null,
-                CancellationToken cancellationToken = default);
-
-        /// <summary>
-        /// Get all cards from a customer.
-        /// </summary>
-        /// <param name="customerId">Required parameter: Customer Id.</param>
-        /// <param name="page">Optional parameter: Page number.</param>
-        /// <param name="size">Optional parameter: Page size.</param>
-        /// <returns>Returns the Models.ListCardsResponse response from the API call.</returns>
-        Models.ListCardsResponse GetCards(
-                string customerId,
-                int? page = null,
-                int? size = null);
-
-        /// <summary>
-        /// Get all cards from a customer.
-        /// </summary>
-        /// <param name="customerId">Required parameter: Customer Id.</param>
-        /// <param name="page">Optional parameter: Page number.</param>
-        /// <param name="size">Optional parameter: Page size.</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.ListCardsResponse response from the API call.</returns>
-        Task<Models.ListCardsResponse> GetCardsAsync(
-                string customerId,
-                int? page = null,
-                int? size = null,
-                CancellationToken cancellationToken = default);
-
-        /// <summary>
-        /// Renew a card.
-        /// </summary>
-        /// <param name="customerId">Required parameter: Customer id.</param>
-        /// <param name="cardId">Required parameter: Card Id.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <returns>Returns the Models.GetCardResponse response from the API call.</returns>
-        Models.GetCardResponse RenewCard(
-                string customerId,
-                string cardId,
-                string idempotencyKey = null);
-
-        /// <summary>
-        /// Renew a card.
-        /// </summary>
-        /// <param name="customerId">Required parameter: Customer id.</param>
-        /// <param name="cardId">Required parameter: Card Id.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetCardResponse response from the API call.</returns>
-        Task<Models.GetCardResponse> RenewCardAsync(
-                string customerId,
-                string cardId,
-                string idempotencyKey = null,
-                CancellationToken cancellationToken = default);
-
-        /// <summary>
-        /// Get a Customer's access token.
-        /// </summary>
-        /// <param name="customerId">Required parameter: Customer Id.</param>
-        /// <param name="tokenId">Required parameter: Token Id.</param>
-        /// <returns>Returns the Models.GetAccessTokenResponse response from the API call.</returns>
-        Models.GetAccessTokenResponse GetAccessToken(
-                string customerId,
-                string tokenId);
-
-        /// <summary>
-        /// Get a Customer's access token.
-        /// </summary>
-        /// <param name="customerId">Required parameter: Customer Id.</param>
-        /// <param name="tokenId">Required parameter: Token Id.</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetAccessTokenResponse response from the API call.</returns>
-        Task<Models.GetAccessTokenResponse> GetAccessTokenAsync(
-                string customerId,
-                string tokenId,
-                CancellationToken cancellationToken = default);
-
-        /// <summary>
-        /// Updates the metadata a customer.
-        /// </summary>
-        /// <param name="customerId">Required parameter: The customer id.</param>
-        /// <param name="request">Required parameter: Request for updating the customer metadata.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <returns>Returns the Models.GetCustomerResponse response from the API call.</returns>
-        Models.GetCustomerResponse UpdateCustomerMetadata(
-                string customerId,
-                Models.UpdateMetadataRequest request,
-                string idempotencyKey = null);
-
-        /// <summary>
-        /// Updates the metadata a customer.
-        /// </summary>
-        /// <param name="customerId">Required parameter: The customer id.</param>
-        /// <param name="request">Required parameter: Request for updating the customer metadata.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetCustomerResponse response from the API call.</returns>
-        Task<Models.GetCustomerResponse> UpdateCustomerMetadataAsync(
-                string customerId,
-                Models.UpdateMetadataRequest request,
                 string idempotencyKey = null,
                 CancellationToken cancellationToken = default);
 
@@ -532,28 +554,6 @@ namespace PagarmeApiSDK.Standard.Controllers
         /// <returns>Returns the Models.GetCustomerResponse response from the API call.</returns>
         Task<Models.GetCustomerResponse> GetCustomerAsync(
                 string customerId,
-                CancellationToken cancellationToken = default);
-
-        /// <summary>
-        /// Get a customer's card.
-        /// </summary>
-        /// <param name="customerId">Required parameter: Customer id.</param>
-        /// <param name="cardId">Required parameter: Card id.</param>
-        /// <returns>Returns the Models.GetCardResponse response from the API call.</returns>
-        Models.GetCardResponse GetCard(
-                string customerId,
-                string cardId);
-
-        /// <summary>
-        /// Get a customer's card.
-        /// </summary>
-        /// <param name="customerId">Required parameter: Customer id.</param>
-        /// <param name="cardId">Required parameter: Card id.</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetCardResponse response from the API call.</returns>
-        Task<Models.GetCardResponse> GetCardAsync(
-                string customerId,
-                string cardId,
                 CancellationToken cancellationToken = default);
     }
 }

--- a/PagarmeApiSDK.Standard/Controllers/IInvoicesController.cs
+++ b/PagarmeApiSDK.Standard/Controllers/IInvoicesController.cs
@@ -23,72 +23,6 @@ namespace PagarmeApiSDK.Standard.Controllers
     public interface IInvoicesController
     {
         /// <summary>
-        /// Updates the metadata from an invoice.
-        /// </summary>
-        /// <param name="invoiceId">Required parameter: The invoice id.</param>
-        /// <param name="request">Required parameter: Request for updating the invoice metadata.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <returns>Returns the Models.GetInvoiceResponse response from the API call.</returns>
-        Models.GetInvoiceResponse UpdateInvoiceMetadata(
-                string invoiceId,
-                Models.UpdateMetadataRequest request,
-                string idempotencyKey = null);
-
-        /// <summary>
-        /// Updates the metadata from an invoice.
-        /// </summary>
-        /// <param name="invoiceId">Required parameter: The invoice id.</param>
-        /// <param name="request">Required parameter: Request for updating the invoice metadata.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetInvoiceResponse response from the API call.</returns>
-        Task<Models.GetInvoiceResponse> UpdateInvoiceMetadataAsync(
-                string invoiceId,
-                Models.UpdateMetadataRequest request,
-                string idempotencyKey = null,
-                CancellationToken cancellationToken = default);
-
-        /// <summary>
-        /// GetPartialInvoice EndPoint.
-        /// </summary>
-        /// <param name="subscriptionId">Required parameter: Subscription Id.</param>
-        /// <returns>Returns the Models.GetInvoiceResponse response from the API call.</returns>
-        Models.GetInvoiceResponse GetPartialInvoice(
-                string subscriptionId);
-
-        /// <summary>
-        /// GetPartialInvoice EndPoint.
-        /// </summary>
-        /// <param name="subscriptionId">Required parameter: Subscription Id.</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetInvoiceResponse response from the API call.</returns>
-        Task<Models.GetInvoiceResponse> GetPartialInvoiceAsync(
-                string subscriptionId,
-                CancellationToken cancellationToken = default);
-
-        /// <summary>
-        /// Cancels an invoice.
-        /// </summary>
-        /// <param name="invoiceId">Required parameter: Invoice id.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <returns>Returns the Models.GetInvoiceResponse response from the API call.</returns>
-        Models.GetInvoiceResponse CancelInvoice(
-                string invoiceId,
-                string idempotencyKey = null);
-
-        /// <summary>
-        /// Cancels an invoice.
-        /// </summary>
-        /// <param name="invoiceId">Required parameter: Invoice id.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetInvoiceResponse response from the API call.</returns>
-        Task<Models.GetInvoiceResponse> CancelInvoiceAsync(
-                string invoiceId,
-                string idempotencyKey = null,
-                CancellationToken cancellationToken = default);
-
-        /// <summary>
         /// Create an Invoice.
         /// </summary>
         /// <param name="subscriptionId">Required parameter: Subscription Id.</param>
@@ -177,21 +111,69 @@ namespace PagarmeApiSDK.Standard.Controllers
                 CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Gets an invoice.
+        /// Cancels an invoice.
         /// </summary>
-        /// <param name="invoiceId">Required parameter: Invoice Id.</param>
+        /// <param name="invoiceId">Required parameter: Invoice id.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
         /// <returns>Returns the Models.GetInvoiceResponse response from the API call.</returns>
-        Models.GetInvoiceResponse GetInvoice(
-                string invoiceId);
+        Models.GetInvoiceResponse CancelInvoice(
+                string invoiceId,
+                string idempotencyKey = null);
 
         /// <summary>
-        /// Gets an invoice.
+        /// Cancels an invoice.
         /// </summary>
-        /// <param name="invoiceId">Required parameter: Invoice Id.</param>
+        /// <param name="invoiceId">Required parameter: Invoice id.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
         /// <param name="cancellationToken"> cancellationToken. </param>
         /// <returns>Returns the Models.GetInvoiceResponse response from the API call.</returns>
-        Task<Models.GetInvoiceResponse> GetInvoiceAsync(
+        Task<Models.GetInvoiceResponse> CancelInvoiceAsync(
                 string invoiceId,
+                string idempotencyKey = null,
+                CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Updates the metadata from an invoice.
+        /// </summary>
+        /// <param name="invoiceId">Required parameter: The invoice id.</param>
+        /// <param name="request">Required parameter: Request for updating the invoice metadata.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <returns>Returns the Models.GetInvoiceResponse response from the API call.</returns>
+        Models.GetInvoiceResponse UpdateInvoiceMetadata(
+                string invoiceId,
+                Models.UpdateMetadataRequest request,
+                string idempotencyKey = null);
+
+        /// <summary>
+        /// Updates the metadata from an invoice.
+        /// </summary>
+        /// <param name="invoiceId">Required parameter: The invoice id.</param>
+        /// <param name="request">Required parameter: Request for updating the invoice metadata.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetInvoiceResponse response from the API call.</returns>
+        Task<Models.GetInvoiceResponse> UpdateInvoiceMetadataAsync(
+                string invoiceId,
+                Models.UpdateMetadataRequest request,
+                string idempotencyKey = null,
+                CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// GetPartialInvoice EndPoint.
+        /// </summary>
+        /// <param name="subscriptionId">Required parameter: Subscription Id.</param>
+        /// <returns>Returns the Models.GetInvoiceResponse response from the API call.</returns>
+        Models.GetInvoiceResponse GetPartialInvoice(
+                string subscriptionId);
+
+        /// <summary>
+        /// GetPartialInvoice EndPoint.
+        /// </summary>
+        /// <param name="subscriptionId">Required parameter: Subscription Id.</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetInvoiceResponse response from the API call.</returns>
+        Task<Models.GetInvoiceResponse> GetPartialInvoiceAsync(
+                string subscriptionId,
                 CancellationToken cancellationToken = default);
 
         /// <summary>
@@ -218,6 +200,24 @@ namespace PagarmeApiSDK.Standard.Controllers
                 string invoiceId,
                 Models.UpdateInvoiceStatusRequest request,
                 string idempotencyKey = null,
+                CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Gets an invoice.
+        /// </summary>
+        /// <param name="invoiceId">Required parameter: Invoice Id.</param>
+        /// <returns>Returns the Models.GetInvoiceResponse response from the API call.</returns>
+        Models.GetInvoiceResponse GetInvoice(
+                string invoiceId);
+
+        /// <summary>
+        /// Gets an invoice.
+        /// </summary>
+        /// <param name="invoiceId">Required parameter: Invoice Id.</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetInvoiceResponse response from the API call.</returns>
+        Task<Models.GetInvoiceResponse> GetInvoiceAsync(
+                string invoiceId,
                 CancellationToken cancellationToken = default);
     }
 }

--- a/PagarmeApiSDK.Standard/Controllers/IOrdersController.cs
+++ b/PagarmeApiSDK.Standard/Controllers/IOrdersController.cs
@@ -65,6 +65,94 @@ namespace PagarmeApiSDK.Standard.Controllers
                 CancellationToken cancellationToken = default);
 
         /// <summary>
+        /// GetOrderItem EndPoint.
+        /// </summary>
+        /// <param name="orderId">Required parameter: Order Id.</param>
+        /// <param name="itemId">Required parameter: Item Id.</param>
+        /// <returns>Returns the Models.GetOrderItemResponse response from the API call.</returns>
+        Models.GetOrderItemResponse GetOrderItem(
+                string orderId,
+                string itemId);
+
+        /// <summary>
+        /// GetOrderItem EndPoint.
+        /// </summary>
+        /// <param name="orderId">Required parameter: Order Id.</param>
+        /// <param name="itemId">Required parameter: Item Id.</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetOrderItemResponse response from the API call.</returns>
+        Task<Models.GetOrderItemResponse> GetOrderItemAsync(
+                string orderId,
+                string itemId,
+                CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Gets an order.
+        /// </summary>
+        /// <param name="orderId">Required parameter: Order id.</param>
+        /// <returns>Returns the Models.GetOrderResponse response from the API call.</returns>
+        Models.GetOrderResponse GetOrder(
+                string orderId);
+
+        /// <summary>
+        /// Gets an order.
+        /// </summary>
+        /// <param name="orderId">Required parameter: Order id.</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetOrderResponse response from the API call.</returns>
+        Task<Models.GetOrderResponse> GetOrderAsync(
+                string orderId,
+                CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// CloseOrder EndPoint.
+        /// </summary>
+        /// <param name="id">Required parameter: Order Id.</param>
+        /// <param name="request">Required parameter: Update Order Model.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <returns>Returns the Models.GetOrderResponse response from the API call.</returns>
+        Models.GetOrderResponse CloseOrder(
+                string id,
+                Models.UpdateOrderStatusRequest request,
+                string idempotencyKey = null);
+
+        /// <summary>
+        /// CloseOrder EndPoint.
+        /// </summary>
+        /// <param name="id">Required parameter: Order Id.</param>
+        /// <param name="request">Required parameter: Update Order Model.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetOrderResponse response from the API call.</returns>
+        Task<Models.GetOrderResponse> CloseOrderAsync(
+                string id,
+                Models.UpdateOrderStatusRequest request,
+                string idempotencyKey = null,
+                CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Creates a new Order.
+        /// </summary>
+        /// <param name="body">Required parameter: Request for creating an order.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <returns>Returns the Models.GetOrderResponse response from the API call.</returns>
+        Models.GetOrderResponse CreateOrder(
+                Models.CreateOrderRequest body,
+                string idempotencyKey = null);
+
+        /// <summary>
+        /// Creates a new Order.
+        /// </summary>
+        /// <param name="body">Required parameter: Request for creating an order.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetOrderResponse response from the API call.</returns>
+        Task<Models.GetOrderResponse> CreateOrderAsync(
+                Models.CreateOrderRequest body,
+                string idempotencyKey = null,
+                CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// UpdateOrderItem EndPoint.
         /// </summary>
         /// <param name="orderId">Required parameter: Order Id.</param>
@@ -117,6 +205,32 @@ namespace PagarmeApiSDK.Standard.Controllers
                 CancellationToken cancellationToken = default);
 
         /// <summary>
+        /// Updates the metadata from an order.
+        /// </summary>
+        /// <param name="orderId">Required parameter: The order id.</param>
+        /// <param name="request">Required parameter: Request for updating the order metadata.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <returns>Returns the Models.GetOrderResponse response from the API call.</returns>
+        Models.GetOrderResponse UpdateOrderMetadata(
+                string orderId,
+                Models.UpdateMetadataRequest request,
+                string idempotencyKey = null);
+
+        /// <summary>
+        /// Updates the metadata from an order.
+        /// </summary>
+        /// <param name="orderId">Required parameter: The order id.</param>
+        /// <param name="request">Required parameter: Request for updating the order metadata.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetOrderResponse response from the API call.</returns>
+        Task<Models.GetOrderResponse> UpdateOrderMetadataAsync(
+                string orderId,
+                Models.UpdateMetadataRequest request,
+                string idempotencyKey = null,
+                CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// DeleteOrderItem EndPoint.
         /// </summary>
         /// <param name="orderId">Required parameter: Order Id.</param>
@@ -139,54 +253,6 @@ namespace PagarmeApiSDK.Standard.Controllers
         Task<Models.GetOrderItemResponse> DeleteOrderItemAsync(
                 string orderId,
                 string itemId,
-                string idempotencyKey = null,
-                CancellationToken cancellationToken = default);
-
-        /// <summary>
-        /// CloseOrder EndPoint.
-        /// </summary>
-        /// <param name="id">Required parameter: Order Id.</param>
-        /// <param name="request">Required parameter: Update Order Model.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <returns>Returns the Models.GetOrderResponse response from the API call.</returns>
-        Models.GetOrderResponse CloseOrder(
-                string id,
-                Models.UpdateOrderStatusRequest request,
-                string idempotencyKey = null);
-
-        /// <summary>
-        /// CloseOrder EndPoint.
-        /// </summary>
-        /// <param name="id">Required parameter: Order Id.</param>
-        /// <param name="request">Required parameter: Update Order Model.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetOrderResponse response from the API call.</returns>
-        Task<Models.GetOrderResponse> CloseOrderAsync(
-                string id,
-                Models.UpdateOrderStatusRequest request,
-                string idempotencyKey = null,
-                CancellationToken cancellationToken = default);
-
-        /// <summary>
-        /// Creates a new Order.
-        /// </summary>
-        /// <param name="body">Required parameter: Request for creating an order.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <returns>Returns the Models.GetOrderResponse response from the API call.</returns>
-        Models.GetOrderResponse CreateOrder(
-                Models.CreateOrderRequest body,
-                string idempotencyKey = null);
-
-        /// <summary>
-        /// Creates a new Order.
-        /// </summary>
-        /// <param name="body">Required parameter: Request for creating an order.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetOrderResponse response from the API call.</returns>
-        Task<Models.GetOrderResponse> CreateOrderAsync(
-                Models.CreateOrderRequest body,
                 string idempotencyKey = null,
                 CancellationToken cancellationToken = default);
 
@@ -214,72 +280,6 @@ namespace PagarmeApiSDK.Standard.Controllers
                 string orderId,
                 Models.CreateOrderItemRequest request,
                 string idempotencyKey = null,
-                CancellationToken cancellationToken = default);
-
-        /// <summary>
-        /// GetOrderItem EndPoint.
-        /// </summary>
-        /// <param name="orderId">Required parameter: Order Id.</param>
-        /// <param name="itemId">Required parameter: Item Id.</param>
-        /// <returns>Returns the Models.GetOrderItemResponse response from the API call.</returns>
-        Models.GetOrderItemResponse GetOrderItem(
-                string orderId,
-                string itemId);
-
-        /// <summary>
-        /// GetOrderItem EndPoint.
-        /// </summary>
-        /// <param name="orderId">Required parameter: Order Id.</param>
-        /// <param name="itemId">Required parameter: Item Id.</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetOrderItemResponse response from the API call.</returns>
-        Task<Models.GetOrderItemResponse> GetOrderItemAsync(
-                string orderId,
-                string itemId,
-                CancellationToken cancellationToken = default);
-
-        /// <summary>
-        /// Updates the metadata from an order.
-        /// </summary>
-        /// <param name="orderId">Required parameter: The order id.</param>
-        /// <param name="request">Required parameter: Request for updating the order metadata.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <returns>Returns the Models.GetOrderResponse response from the API call.</returns>
-        Models.GetOrderResponse UpdateOrderMetadata(
-                string orderId,
-                Models.UpdateMetadataRequest request,
-                string idempotencyKey = null);
-
-        /// <summary>
-        /// Updates the metadata from an order.
-        /// </summary>
-        /// <param name="orderId">Required parameter: The order id.</param>
-        /// <param name="request">Required parameter: Request for updating the order metadata.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetOrderResponse response from the API call.</returns>
-        Task<Models.GetOrderResponse> UpdateOrderMetadataAsync(
-                string orderId,
-                Models.UpdateMetadataRequest request,
-                string idempotencyKey = null,
-                CancellationToken cancellationToken = default);
-
-        /// <summary>
-        /// Gets an order.
-        /// </summary>
-        /// <param name="orderId">Required parameter: Order id.</param>
-        /// <returns>Returns the Models.GetOrderResponse response from the API call.</returns>
-        Models.GetOrderResponse GetOrder(
-                string orderId);
-
-        /// <summary>
-        /// Gets an order.
-        /// </summary>
-        /// <param name="orderId">Required parameter: Order id.</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetOrderResponse response from the API call.</returns>
-        Task<Models.GetOrderResponse> GetOrderAsync(
-                string orderId,
                 CancellationToken cancellationToken = default);
     }
 }

--- a/PagarmeApiSDK.Standard/Controllers/IPlansController.cs
+++ b/PagarmeApiSDK.Standard/Controllers/IPlansController.cs
@@ -41,24 +41,28 @@ namespace PagarmeApiSDK.Standard.Controllers
                 CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Deletes a plan.
+        /// Updates a plan.
         /// </summary>
         /// <param name="planId">Required parameter: Plan id.</param>
+        /// <param name="request">Required parameter: Request for updating a plan.</param>
         /// <param name="idempotencyKey">Optional parameter: Example: .</param>
         /// <returns>Returns the Models.GetPlanResponse response from the API call.</returns>
-        Models.GetPlanResponse DeletePlan(
+        Models.GetPlanResponse UpdatePlan(
                 string planId,
+                Models.UpdatePlanRequest request,
                 string idempotencyKey = null);
 
         /// <summary>
-        /// Deletes a plan.
+        /// Updates a plan.
         /// </summary>
         /// <param name="planId">Required parameter: Plan id.</param>
+        /// <param name="request">Required parameter: Request for updating a plan.</param>
         /// <param name="idempotencyKey">Optional parameter: Example: .</param>
         /// <param name="cancellationToken"> cancellationToken. </param>
         /// <returns>Returns the Models.GetPlanResponse response from the API call.</returns>
-        Task<Models.GetPlanResponse> DeletePlanAsync(
+        Task<Models.GetPlanResponse> UpdatePlanAsync(
                 string planId,
+                Models.UpdatePlanRequest request,
                 string idempotencyKey = null,
                 CancellationToken cancellationToken = default);
 
@@ -85,106 +89,6 @@ namespace PagarmeApiSDK.Standard.Controllers
         Task<Models.GetPlanResponse> UpdatePlanMetadataAsync(
                 string planId,
                 Models.UpdateMetadataRequest request,
-                string idempotencyKey = null,
-                CancellationToken cancellationToken = default);
-
-        /// <summary>
-        /// Updates a plan item.
-        /// </summary>
-        /// <param name="planId">Required parameter: Plan id.</param>
-        /// <param name="planItemId">Required parameter: Plan item id.</param>
-        /// <param name="body">Required parameter: Request for updating the plan item.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <returns>Returns the Models.GetPlanItemResponse response from the API call.</returns>
-        Models.GetPlanItemResponse UpdatePlanItem(
-                string planId,
-                string planItemId,
-                Models.UpdatePlanItemRequest body,
-                string idempotencyKey = null);
-
-        /// <summary>
-        /// Updates a plan item.
-        /// </summary>
-        /// <param name="planId">Required parameter: Plan id.</param>
-        /// <param name="planItemId">Required parameter: Plan item id.</param>
-        /// <param name="body">Required parameter: Request for updating the plan item.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetPlanItemResponse response from the API call.</returns>
-        Task<Models.GetPlanItemResponse> UpdatePlanItemAsync(
-                string planId,
-                string planItemId,
-                Models.UpdatePlanItemRequest body,
-                string idempotencyKey = null,
-                CancellationToken cancellationToken = default);
-
-        /// <summary>
-        /// Adds a new item to a plan.
-        /// </summary>
-        /// <param name="planId">Required parameter: Plan id.</param>
-        /// <param name="request">Required parameter: Request for creating a plan item.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <returns>Returns the Models.GetPlanItemResponse response from the API call.</returns>
-        Models.GetPlanItemResponse CreatePlanItem(
-                string planId,
-                Models.CreatePlanItemRequest request,
-                string idempotencyKey = null);
-
-        /// <summary>
-        /// Adds a new item to a plan.
-        /// </summary>
-        /// <param name="planId">Required parameter: Plan id.</param>
-        /// <param name="request">Required parameter: Request for creating a plan item.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetPlanItemResponse response from the API call.</returns>
-        Task<Models.GetPlanItemResponse> CreatePlanItemAsync(
-                string planId,
-                Models.CreatePlanItemRequest request,
-                string idempotencyKey = null,
-                CancellationToken cancellationToken = default);
-
-        /// <summary>
-        /// Gets a plan item.
-        /// </summary>
-        /// <param name="planId">Required parameter: Plan id.</param>
-        /// <param name="planItemId">Required parameter: Plan item id.</param>
-        /// <returns>Returns the Models.GetPlanItemResponse response from the API call.</returns>
-        Models.GetPlanItemResponse GetPlanItem(
-                string planId,
-                string planItemId);
-
-        /// <summary>
-        /// Gets a plan item.
-        /// </summary>
-        /// <param name="planId">Required parameter: Plan id.</param>
-        /// <param name="planItemId">Required parameter: Plan item id.</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetPlanItemResponse response from the API call.</returns>
-        Task<Models.GetPlanItemResponse> GetPlanItemAsync(
-                string planId,
-                string planItemId,
-                CancellationToken cancellationToken = default);
-
-        /// <summary>
-        /// Creates a new plan.
-        /// </summary>
-        /// <param name="body">Required parameter: Request for creating a plan.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <returns>Returns the Models.GetPlanResponse response from the API call.</returns>
-        Models.GetPlanResponse CreatePlan(
-                Models.CreatePlanRequest body,
-                string idempotencyKey = null);
-
-        /// <summary>
-        /// Creates a new plan.
-        /// </summary>
-        /// <param name="body">Required parameter: Request for creating a plan.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetPlanResponse response from the API call.</returns>
-        Task<Models.GetPlanResponse> CreatePlanAsync(
-                Models.CreatePlanRequest body,
                 string idempotencyKey = null,
                 CancellationToken cancellationToken = default);
 
@@ -257,28 +161,124 @@ namespace PagarmeApiSDK.Standard.Controllers
                 CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Updates a plan.
+        /// Gets a plan item.
         /// </summary>
         /// <param name="planId">Required parameter: Plan id.</param>
-        /// <param name="request">Required parameter: Request for updating a plan.</param>
+        /// <param name="planItemId">Required parameter: Plan item id.</param>
+        /// <returns>Returns the Models.GetPlanItemResponse response from the API call.</returns>
+        Models.GetPlanItemResponse GetPlanItem(
+                string planId,
+                string planItemId);
+
+        /// <summary>
+        /// Gets a plan item.
+        /// </summary>
+        /// <param name="planId">Required parameter: Plan id.</param>
+        /// <param name="planItemId">Required parameter: Plan item id.</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetPlanItemResponse response from the API call.</returns>
+        Task<Models.GetPlanItemResponse> GetPlanItemAsync(
+                string planId,
+                string planItemId,
+                CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Deletes a plan.
+        /// </summary>
+        /// <param name="planId">Required parameter: Plan id.</param>
         /// <param name="idempotencyKey">Optional parameter: Example: .</param>
         /// <returns>Returns the Models.GetPlanResponse response from the API call.</returns>
-        Models.GetPlanResponse UpdatePlan(
+        Models.GetPlanResponse DeletePlan(
                 string planId,
-                Models.UpdatePlanRequest request,
                 string idempotencyKey = null);
 
         /// <summary>
-        /// Updates a plan.
+        /// Deletes a plan.
         /// </summary>
         /// <param name="planId">Required parameter: Plan id.</param>
-        /// <param name="request">Required parameter: Request for updating a plan.</param>
         /// <param name="idempotencyKey">Optional parameter: Example: .</param>
         /// <param name="cancellationToken"> cancellationToken. </param>
         /// <returns>Returns the Models.GetPlanResponse response from the API call.</returns>
-        Task<Models.GetPlanResponse> UpdatePlanAsync(
+        Task<Models.GetPlanResponse> DeletePlanAsync(
                 string planId,
-                Models.UpdatePlanRequest request,
+                string idempotencyKey = null,
+                CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Updates a plan item.
+        /// </summary>
+        /// <param name="planId">Required parameter: Plan id.</param>
+        /// <param name="planItemId">Required parameter: Plan item id.</param>
+        /// <param name="body">Required parameter: Request for updating the plan item.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <returns>Returns the Models.GetPlanItemResponse response from the API call.</returns>
+        Models.GetPlanItemResponse UpdatePlanItem(
+                string planId,
+                string planItemId,
+                Models.UpdatePlanItemRequest body,
+                string idempotencyKey = null);
+
+        /// <summary>
+        /// Updates a plan item.
+        /// </summary>
+        /// <param name="planId">Required parameter: Plan id.</param>
+        /// <param name="planItemId">Required parameter: Plan item id.</param>
+        /// <param name="body">Required parameter: Request for updating the plan item.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetPlanItemResponse response from the API call.</returns>
+        Task<Models.GetPlanItemResponse> UpdatePlanItemAsync(
+                string planId,
+                string planItemId,
+                Models.UpdatePlanItemRequest body,
+                string idempotencyKey = null,
+                CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Adds a new item to a plan.
+        /// </summary>
+        /// <param name="planId">Required parameter: Plan id.</param>
+        /// <param name="request">Required parameter: Request for creating a plan item.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <returns>Returns the Models.GetPlanItemResponse response from the API call.</returns>
+        Models.GetPlanItemResponse CreatePlanItem(
+                string planId,
+                Models.CreatePlanItemRequest request,
+                string idempotencyKey = null);
+
+        /// <summary>
+        /// Adds a new item to a plan.
+        /// </summary>
+        /// <param name="planId">Required parameter: Plan id.</param>
+        /// <param name="request">Required parameter: Request for creating a plan item.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetPlanItemResponse response from the API call.</returns>
+        Task<Models.GetPlanItemResponse> CreatePlanItemAsync(
+                string planId,
+                Models.CreatePlanItemRequest request,
+                string idempotencyKey = null,
+                CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Creates a new plan.
+        /// </summary>
+        /// <param name="body">Required parameter: Request for creating a plan.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <returns>Returns the Models.GetPlanResponse response from the API call.</returns>
+        Models.GetPlanResponse CreatePlan(
+                Models.CreatePlanRequest body,
+                string idempotencyKey = null);
+
+        /// <summary>
+        /// Creates a new plan.
+        /// </summary>
+        /// <param name="body">Required parameter: Request for creating a plan.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetPlanResponse response from the API call.</returns>
+        Task<Models.GetPlanResponse> CreatePlanAsync(
+                Models.CreatePlanRequest body,
                 string idempotencyKey = null,
                 CancellationToken cancellationToken = default);
     }

--- a/PagarmeApiSDK.Standard/Controllers/IRecipientsController.cs
+++ b/PagarmeApiSDK.Standard/Controllers/IRecipientsController.cs
@@ -123,54 +123,6 @@ namespace PagarmeApiSDK.Standard.Controllers
                 CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// GetWithdrawById EndPoint.
-        /// </summary>
-        /// <param name="recipientId">Required parameter: Example: .</param>
-        /// <param name="withdrawalId">Required parameter: Example: .</param>
-        /// <returns>Returns the Models.GetWithdrawResponse response from the API call.</returns>
-        Models.GetWithdrawResponse GetWithdrawById(
-                string recipientId,
-                string withdrawalId);
-
-        /// <summary>
-        /// GetWithdrawById EndPoint.
-        /// </summary>
-        /// <param name="recipientId">Required parameter: Example: .</param>
-        /// <param name="withdrawalId">Required parameter: Example: .</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetWithdrawResponse response from the API call.</returns>
-        Task<Models.GetWithdrawResponse> GetWithdrawByIdAsync(
-                string recipientId,
-                string withdrawalId,
-                CancellationToken cancellationToken = default);
-
-        /// <summary>
-        /// Updates the default bank account from a recipient.
-        /// </summary>
-        /// <param name="recipientId">Required parameter: Recipient id.</param>
-        /// <param name="request">Required parameter: Bank account data.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <returns>Returns the Models.GetRecipientResponse response from the API call.</returns>
-        Models.GetRecipientResponse UpdateRecipientDefaultBankAccount(
-                string recipientId,
-                Models.UpdateRecipientBankAccountRequest request,
-                string idempotencyKey = null);
-
-        /// <summary>
-        /// Updates the default bank account from a recipient.
-        /// </summary>
-        /// <param name="recipientId">Required parameter: Recipient id.</param>
-        /// <param name="request">Required parameter: Bank account data.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetRecipientResponse response from the API call.</returns>
-        Task<Models.GetRecipientResponse> UpdateRecipientDefaultBankAccountAsync(
-                string recipientId,
-                Models.UpdateRecipientBankAccountRequest request,
-                string idempotencyKey = null,
-                CancellationToken cancellationToken = default);
-
-        /// <summary>
         /// Updates recipient metadata.
         /// </summary>
         /// <param name="recipientId">Required parameter: Recipient id.</param>
@@ -197,44 +149,6 @@ namespace PagarmeApiSDK.Standard.Controllers
                 CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Gets a paginated list of transfers for the recipient.
-        /// </summary>
-        /// <param name="recipientId">Required parameter: Recipient id.</param>
-        /// <param name="page">Optional parameter: Page number.</param>
-        /// <param name="size">Optional parameter: Page size.</param>
-        /// <param name="status">Optional parameter: Filter for transfer status.</param>
-        /// <param name="createdSince">Optional parameter: Filter for start range of transfer creation date.</param>
-        /// <param name="createdUntil">Optional parameter: Filter for end range of transfer creation date.</param>
-        /// <returns>Returns the Models.ListTransferResponse response from the API call.</returns>
-        Models.ListTransferResponse GetTransfers(
-                string recipientId,
-                int? page = null,
-                int? size = null,
-                string status = null,
-                DateTime? createdSince = null,
-                DateTime? createdUntil = null);
-
-        /// <summary>
-        /// Gets a paginated list of transfers for the recipient.
-        /// </summary>
-        /// <param name="recipientId">Required parameter: Recipient id.</param>
-        /// <param name="page">Optional parameter: Page number.</param>
-        /// <param name="size">Optional parameter: Page size.</param>
-        /// <param name="status">Optional parameter: Filter for transfer status.</param>
-        /// <param name="createdSince">Optional parameter: Filter for start range of transfer creation date.</param>
-        /// <param name="createdUntil">Optional parameter: Filter for end range of transfer creation date.</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.ListTransferResponse response from the API call.</returns>
-        Task<Models.ListTransferResponse> GetTransfersAsync(
-                string recipientId,
-                int? page = null,
-                int? size = null,
-                string status = null,
-                DateTime? createdSince = null,
-                DateTime? createdUntil = null,
-                CancellationToken cancellationToken = default);
-
-        /// <summary>
         /// Gets a transfer.
         /// </summary>
         /// <param name="recipientId">Required parameter: Recipient id.</param>
@@ -254,54 +168,6 @@ namespace PagarmeApiSDK.Standard.Controllers
         Task<Models.GetTransferResponse> GetTransferAsync(
                 string recipientId,
                 string transferId,
-                CancellationToken cancellationToken = default);
-
-        /// <summary>
-        /// CreateWithdraw EndPoint.
-        /// </summary>
-        /// <param name="recipientId">Required parameter: Example: .</param>
-        /// <param name="request">Required parameter: Example: .</param>
-        /// <returns>Returns the Models.GetWithdrawResponse response from the API call.</returns>
-        Models.GetWithdrawResponse CreateWithdraw(
-                string recipientId,
-                Models.CreateWithdrawRequest request);
-
-        /// <summary>
-        /// CreateWithdraw EndPoint.
-        /// </summary>
-        /// <param name="recipientId">Required parameter: Example: .</param>
-        /// <param name="request">Required parameter: Example: .</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetWithdrawResponse response from the API call.</returns>
-        Task<Models.GetWithdrawResponse> CreateWithdrawAsync(
-                string recipientId,
-                Models.CreateWithdrawRequest request,
-                CancellationToken cancellationToken = default);
-
-        /// <summary>
-        /// Updates recipient metadata.
-        /// </summary>
-        /// <param name="recipientId">Required parameter: Recipient id.</param>
-        /// <param name="request">Required parameter: Metadata.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <returns>Returns the Models.GetRecipientResponse response from the API call.</returns>
-        Models.GetRecipientResponse UpdateAutomaticAnticipationSettings(
-                string recipientId,
-                Models.UpdateAutomaticAnticipationSettingsRequest request,
-                string idempotencyKey = null);
-
-        /// <summary>
-        /// Updates recipient metadata.
-        /// </summary>
-        /// <param name="recipientId">Required parameter: Recipient id.</param>
-        /// <param name="request">Required parameter: Metadata.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetRecipientResponse response from the API call.</returns>
-        Task<Models.GetRecipientResponse> UpdateAutomaticAnticipationSettingsAsync(
-                string recipientId,
-                Models.UpdateAutomaticAnticipationSettingsRequest request,
-                string idempotencyKey = null,
                 CancellationToken cancellationToken = default);
 
         /// <summary>
@@ -403,21 +269,51 @@ namespace PagarmeApiSDK.Standard.Controllers
                 CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Retrieves recipient information.
+        /// Updates the default bank account from a recipient.
         /// </summary>
-        /// <param name="recipientId">Required parameter: Recipiend id.</param>
+        /// <param name="recipientId">Required parameter: Recipient id.</param>
+        /// <param name="request">Required parameter: Bank account data.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
         /// <returns>Returns the Models.GetRecipientResponse response from the API call.</returns>
-        Models.GetRecipientResponse GetRecipient(
-                string recipientId);
+        Models.GetRecipientResponse UpdateRecipientDefaultBankAccount(
+                string recipientId,
+                Models.UpdateRecipientBankAccountRequest request,
+                string idempotencyKey = null);
 
         /// <summary>
-        /// Retrieves recipient information.
+        /// Updates the default bank account from a recipient.
         /// </summary>
-        /// <param name="recipientId">Required parameter: Recipiend id.</param>
+        /// <param name="recipientId">Required parameter: Recipient id.</param>
+        /// <param name="request">Required parameter: Bank account data.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
         /// <param name="cancellationToken"> cancellationToken. </param>
         /// <returns>Returns the Models.GetRecipientResponse response from the API call.</returns>
-        Task<Models.GetRecipientResponse> GetRecipientAsync(
+        Task<Models.GetRecipientResponse> UpdateRecipientDefaultBankAccountAsync(
                 string recipientId,
+                Models.UpdateRecipientBankAccountRequest request,
+                string idempotencyKey = null,
+                CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// CreateWithdraw EndPoint.
+        /// </summary>
+        /// <param name="recipientId">Required parameter: Example: .</param>
+        /// <param name="request">Required parameter: Example: .</param>
+        /// <returns>Returns the Models.GetWithdrawResponse response from the API call.</returns>
+        Models.GetWithdrawResponse CreateWithdraw(
+                string recipientId,
+                Models.CreateWithdrawRequest request);
+
+        /// <summary>
+        /// CreateWithdraw EndPoint.
+        /// </summary>
+        /// <param name="recipientId">Required parameter: Example: .</param>
+        /// <param name="request">Required parameter: Example: .</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetWithdrawResponse response from the API call.</returns>
+        Task<Models.GetWithdrawResponse> CreateWithdrawAsync(
+                string recipientId,
+                Models.CreateWithdrawRequest request,
                 CancellationToken cancellationToken = default);
 
         /// <summary>
@@ -436,44 +332,6 @@ namespace PagarmeApiSDK.Standard.Controllers
         /// <returns>Returns the Models.GetBalanceResponse response from the API call.</returns>
         Task<Models.GetBalanceResponse> GetBalanceAsync(
                 string recipientId,
-                CancellationToken cancellationToken = default);
-
-        /// <summary>
-        /// Gets a paginated list of transfers for the recipient.
-        /// </summary>
-        /// <param name="recipientId">Required parameter: Example: .</param>
-        /// <param name="page">Optional parameter: Example: .</param>
-        /// <param name="size">Optional parameter: Example: .</param>
-        /// <param name="status">Optional parameter: Example: .</param>
-        /// <param name="createdSince">Optional parameter: Example: .</param>
-        /// <param name="createdUntil">Optional parameter: Example: .</param>
-        /// <returns>Returns the Models.ListWithdrawals response from the API call.</returns>
-        Models.ListWithdrawals GetWithdrawals(
-                string recipientId,
-                int? page = null,
-                int? size = null,
-                string status = null,
-                DateTime? createdSince = null,
-                DateTime? createdUntil = null);
-
-        /// <summary>
-        /// Gets a paginated list of transfers for the recipient.
-        /// </summary>
-        /// <param name="recipientId">Required parameter: Example: .</param>
-        /// <param name="page">Optional parameter: Example: .</param>
-        /// <param name="size">Optional parameter: Example: .</param>
-        /// <param name="status">Optional parameter: Example: .</param>
-        /// <param name="createdSince">Optional parameter: Example: .</param>
-        /// <param name="createdUntil">Optional parameter: Example: .</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.ListWithdrawals response from the API call.</returns>
-        Task<Models.ListWithdrawals> GetWithdrawalsAsync(
-                string recipientId,
-                int? page = null,
-                int? size = null,
-                string status = null,
-                DateTime? createdSince = null,
-                DateTime? createdUntil = null,
                 CancellationToken cancellationToken = default);
 
         /// <summary>
@@ -522,6 +380,148 @@ namespace PagarmeApiSDK.Standard.Controllers
         Task<Models.GetRecipientResponse> CreateRecipientAsync(
                 Models.CreateRecipientRequest request,
                 string idempotencyKey = null,
+                CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Updates recipient metadata.
+        /// </summary>
+        /// <param name="recipientId">Required parameter: Recipient id.</param>
+        /// <param name="request">Required parameter: Metadata.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <returns>Returns the Models.GetRecipientResponse response from the API call.</returns>
+        Models.GetRecipientResponse UpdateAutomaticAnticipationSettings(
+                string recipientId,
+                Models.UpdateAutomaticAnticipationSettingsRequest request,
+                string idempotencyKey = null);
+
+        /// <summary>
+        /// Updates recipient metadata.
+        /// </summary>
+        /// <param name="recipientId">Required parameter: Recipient id.</param>
+        /// <param name="request">Required parameter: Metadata.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetRecipientResponse response from the API call.</returns>
+        Task<Models.GetRecipientResponse> UpdateAutomaticAnticipationSettingsAsync(
+                string recipientId,
+                Models.UpdateAutomaticAnticipationSettingsRequest request,
+                string idempotencyKey = null,
+                CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Retrieves recipient information.
+        /// </summary>
+        /// <param name="recipientId">Required parameter: Recipiend id.</param>
+        /// <returns>Returns the Models.GetRecipientResponse response from the API call.</returns>
+        Models.GetRecipientResponse GetRecipient(
+                string recipientId);
+
+        /// <summary>
+        /// Retrieves recipient information.
+        /// </summary>
+        /// <param name="recipientId">Required parameter: Recipiend id.</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetRecipientResponse response from the API call.</returns>
+        Task<Models.GetRecipientResponse> GetRecipientAsync(
+                string recipientId,
+                CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Gets a paginated list of transfers for the recipient.
+        /// </summary>
+        /// <param name="recipientId">Required parameter: Example: .</param>
+        /// <param name="page">Optional parameter: Example: .</param>
+        /// <param name="size">Optional parameter: Example: .</param>
+        /// <param name="status">Optional parameter: Example: .</param>
+        /// <param name="createdSince">Optional parameter: Example: .</param>
+        /// <param name="createdUntil">Optional parameter: Example: .</param>
+        /// <returns>Returns the Models.ListWithdrawals response from the API call.</returns>
+        Models.ListWithdrawals GetWithdrawals(
+                string recipientId,
+                int? page = null,
+                int? size = null,
+                string status = null,
+                DateTime? createdSince = null,
+                DateTime? createdUntil = null);
+
+        /// <summary>
+        /// Gets a paginated list of transfers for the recipient.
+        /// </summary>
+        /// <param name="recipientId">Required parameter: Example: .</param>
+        /// <param name="page">Optional parameter: Example: .</param>
+        /// <param name="size">Optional parameter: Example: .</param>
+        /// <param name="status">Optional parameter: Example: .</param>
+        /// <param name="createdSince">Optional parameter: Example: .</param>
+        /// <param name="createdUntil">Optional parameter: Example: .</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.ListWithdrawals response from the API call.</returns>
+        Task<Models.ListWithdrawals> GetWithdrawalsAsync(
+                string recipientId,
+                int? page = null,
+                int? size = null,
+                string status = null,
+                DateTime? createdSince = null,
+                DateTime? createdUntil = null,
+                CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// GetWithdrawById EndPoint.
+        /// </summary>
+        /// <param name="recipientId">Required parameter: Example: .</param>
+        /// <param name="withdrawalId">Required parameter: Example: .</param>
+        /// <returns>Returns the Models.GetWithdrawResponse response from the API call.</returns>
+        Models.GetWithdrawResponse GetWithdrawById(
+                string recipientId,
+                string withdrawalId);
+
+        /// <summary>
+        /// GetWithdrawById EndPoint.
+        /// </summary>
+        /// <param name="recipientId">Required parameter: Example: .</param>
+        /// <param name="withdrawalId">Required parameter: Example: .</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetWithdrawResponse response from the API call.</returns>
+        Task<Models.GetWithdrawResponse> GetWithdrawByIdAsync(
+                string recipientId,
+                string withdrawalId,
+                CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Gets a paginated list of transfers for the recipient.
+        /// </summary>
+        /// <param name="recipientId">Required parameter: Recipient id.</param>
+        /// <param name="page">Optional parameter: Page number.</param>
+        /// <param name="size">Optional parameter: Page size.</param>
+        /// <param name="status">Optional parameter: Filter for transfer status.</param>
+        /// <param name="createdSince">Optional parameter: Filter for start range of transfer creation date.</param>
+        /// <param name="createdUntil">Optional parameter: Filter for end range of transfer creation date.</param>
+        /// <returns>Returns the Models.ListTransferResponse response from the API call.</returns>
+        Models.ListTransferResponse GetTransfers(
+                string recipientId,
+                int? page = null,
+                int? size = null,
+                string status = null,
+                DateTime? createdSince = null,
+                DateTime? createdUntil = null);
+
+        /// <summary>
+        /// Gets a paginated list of transfers for the recipient.
+        /// </summary>
+        /// <param name="recipientId">Required parameter: Recipient id.</param>
+        /// <param name="page">Optional parameter: Page number.</param>
+        /// <param name="size">Optional parameter: Page size.</param>
+        /// <param name="status">Optional parameter: Filter for transfer status.</param>
+        /// <param name="createdSince">Optional parameter: Filter for start range of transfer creation date.</param>
+        /// <param name="createdUntil">Optional parameter: Filter for end range of transfer creation date.</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.ListTransferResponse response from the API call.</returns>
+        Task<Models.ListTransferResponse> GetTransfersAsync(
+                string recipientId,
+                int? page = null,
+                int? size = null,
+                string status = null,
+                DateTime? createdSince = null,
+                DateTime? createdUntil = null,
                 CancellationToken cancellationToken = default);
 
         /// <summary>

--- a/PagarmeApiSDK.Standard/Controllers/ISubscriptionsController.cs
+++ b/PagarmeApiSDK.Standard/Controllers/ISubscriptionsController.cs
@@ -45,139 +45,6 @@ namespace PagarmeApiSDK.Standard.Controllers
                 CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Updates the credit card from a subscription.
-        /// </summary>
-        /// <param name="subscriptionId">Required parameter: Subscription id.</param>
-        /// <param name="request">Required parameter: Request for updating a card.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <returns>Returns the Models.GetSubscriptionResponse response from the API call.</returns>
-        Models.GetSubscriptionResponse UpdateSubscriptionCard(
-                string subscriptionId,
-                Models.UpdateSubscriptionCardRequest request,
-                string idempotencyKey = null);
-
-        /// <summary>
-        /// Updates the credit card from a subscription.
-        /// </summary>
-        /// <param name="subscriptionId">Required parameter: Subscription id.</param>
-        /// <param name="request">Required parameter: Request for updating a card.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetSubscriptionResponse response from the API call.</returns>
-        Task<Models.GetSubscriptionResponse> UpdateSubscriptionCardAsync(
-                string subscriptionId,
-                Models.UpdateSubscriptionCardRequest request,
-                string idempotencyKey = null,
-                CancellationToken cancellationToken = default);
-
-        /// <summary>
-        /// Deletes a usage.
-        /// </summary>
-        /// <param name="subscriptionId">Required parameter: The subscription id.</param>
-        /// <param name="itemId">Required parameter: The subscription item id.</param>
-        /// <param name="usageId">Required parameter: The usage id.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <returns>Returns the Models.GetUsageResponse response from the API call.</returns>
-        Models.GetUsageResponse DeleteUsage(
-                string subscriptionId,
-                string itemId,
-                string usageId,
-                string idempotencyKey = null);
-
-        /// <summary>
-        /// Deletes a usage.
-        /// </summary>
-        /// <param name="subscriptionId">Required parameter: The subscription id.</param>
-        /// <param name="itemId">Required parameter: The subscription item id.</param>
-        /// <param name="usageId">Required parameter: The usage id.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetUsageResponse response from the API call.</returns>
-        Task<Models.GetUsageResponse> DeleteUsageAsync(
-                string subscriptionId,
-                string itemId,
-                string usageId,
-                string idempotencyKey = null,
-                CancellationToken cancellationToken = default);
-
-        /// <summary>
-        /// Creates a discount.
-        /// </summary>
-        /// <param name="subscriptionId">Required parameter: Subscription id.</param>
-        /// <param name="request">Required parameter: Request for creating a discount.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <returns>Returns the Models.GetDiscountResponse response from the API call.</returns>
-        Models.GetDiscountResponse CreateDiscount(
-                string subscriptionId,
-                Models.CreateDiscountRequest request,
-                string idempotencyKey = null);
-
-        /// <summary>
-        /// Creates a discount.
-        /// </summary>
-        /// <param name="subscriptionId">Required parameter: Subscription id.</param>
-        /// <param name="request">Required parameter: Request for creating a discount.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetDiscountResponse response from the API call.</returns>
-        Task<Models.GetDiscountResponse> CreateDiscountAsync(
-                string subscriptionId,
-                Models.CreateDiscountRequest request,
-                string idempotencyKey = null,
-                CancellationToken cancellationToken = default);
-
-        /// <summary>
-        /// Create Usage.
-        /// </summary>
-        /// <param name="subscriptionId">Required parameter: Subscription id.</param>
-        /// <param name="itemId">Required parameter: Item id.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <returns>Returns the Models.GetUsageResponse response from the API call.</returns>
-        Models.GetUsageResponse CreateAnUsage(
-                string subscriptionId,
-                string itemId,
-                string idempotencyKey = null);
-
-        /// <summary>
-        /// Create Usage.
-        /// </summary>
-        /// <param name="subscriptionId">Required parameter: Subscription id.</param>
-        /// <param name="itemId">Required parameter: Item id.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetUsageResponse response from the API call.</returns>
-        Task<Models.GetUsageResponse> CreateAnUsageAsync(
-                string subscriptionId,
-                string itemId,
-                string idempotencyKey = null,
-                CancellationToken cancellationToken = default);
-
-        /// <summary>
-        /// UpdateCurrentCycleStatus EndPoint.
-        /// </summary>
-        /// <param name="subscriptionId">Required parameter: Subscription Id.</param>
-        /// <param name="request">Required parameter: Request for updating the end date of the subscription current status.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        void UpdateCurrentCycleStatus(
-                string subscriptionId,
-                Models.UpdateCurrentCycleStatusRequest request,
-                string idempotencyKey = null);
-
-        /// <summary>
-        /// UpdateCurrentCycleStatus EndPoint.
-        /// </summary>
-        /// <param name="subscriptionId">Required parameter: Subscription Id.</param>
-        /// <param name="request">Required parameter: Request for updating the end date of the subscription current status.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the void response from the API call.</returns>
-        Task UpdateCurrentCycleStatusAsync(
-                string subscriptionId,
-                Models.UpdateCurrentCycleStatusRequest request,
-                string idempotencyKey = null,
-                CancellationToken cancellationToken = default);
-
-        /// <summary>
         /// Deletes a discount.
         /// </summary>
         /// <param name="subscriptionId">Required parameter: Subscription id.</param>
@@ -201,104 +68,6 @@ namespace PagarmeApiSDK.Standard.Controllers
                 string subscriptionId,
                 string discountId,
                 string idempotencyKey = null,
-                CancellationToken cancellationToken = default);
-
-        /// <summary>
-        /// Get Subscription Items.
-        /// </summary>
-        /// <param name="subscriptionId">Required parameter: The subscription id.</param>
-        /// <param name="page">Optional parameter: Page number.</param>
-        /// <param name="size">Optional parameter: Page size.</param>
-        /// <param name="name">Optional parameter: The item name.</param>
-        /// <param name="code">Optional parameter: Identification code in the client system.</param>
-        /// <param name="status">Optional parameter: The item statis.</param>
-        /// <param name="description">Optional parameter: The item description.</param>
-        /// <param name="createdSince">Optional parameter: Filter for item's creation date start range.</param>
-        /// <param name="createdUntil">Optional parameter: Filter for item's creation date end range.</param>
-        /// <returns>Returns the Models.ListSubscriptionItemsResponse response from the API call.</returns>
-        Models.ListSubscriptionItemsResponse GetSubscriptionItems(
-                string subscriptionId,
-                int? page = null,
-                int? size = null,
-                string name = null,
-                string code = null,
-                string status = null,
-                string description = null,
-                string createdSince = null,
-                string createdUntil = null);
-
-        /// <summary>
-        /// Get Subscription Items.
-        /// </summary>
-        /// <param name="subscriptionId">Required parameter: The subscription id.</param>
-        /// <param name="page">Optional parameter: Page number.</param>
-        /// <param name="size">Optional parameter: Page size.</param>
-        /// <param name="name">Optional parameter: The item name.</param>
-        /// <param name="code">Optional parameter: Identification code in the client system.</param>
-        /// <param name="status">Optional parameter: The item statis.</param>
-        /// <param name="description">Optional parameter: The item description.</param>
-        /// <param name="createdSince">Optional parameter: Filter for item's creation date start range.</param>
-        /// <param name="createdUntil">Optional parameter: Filter for item's creation date end range.</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.ListSubscriptionItemsResponse response from the API call.</returns>
-        Task<Models.ListSubscriptionItemsResponse> GetSubscriptionItemsAsync(
-                string subscriptionId,
-                int? page = null,
-                int? size = null,
-                string name = null,
-                string code = null,
-                string status = null,
-                string description = null,
-                string createdSince = null,
-                string createdUntil = null,
-                CancellationToken cancellationToken = default);
-
-        /// <summary>
-        /// Updates the payment method from a subscription.
-        /// </summary>
-        /// <param name="subscriptionId">Required parameter: Subscription id.</param>
-        /// <param name="request">Required parameter: Request for updating the paymentmethod from a subscription.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <returns>Returns the Models.GetSubscriptionResponse response from the API call.</returns>
-        Models.GetSubscriptionResponse UpdateSubscriptionPaymentMethod(
-                string subscriptionId,
-                Models.UpdateSubscriptionPaymentMethodRequest request,
-                string idempotencyKey = null);
-
-        /// <summary>
-        /// Updates the payment method from a subscription.
-        /// </summary>
-        /// <param name="subscriptionId">Required parameter: Subscription id.</param>
-        /// <param name="request">Required parameter: Request for updating the paymentmethod from a subscription.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetSubscriptionResponse response from the API call.</returns>
-        Task<Models.GetSubscriptionResponse> UpdateSubscriptionPaymentMethodAsync(
-                string subscriptionId,
-                Models.UpdateSubscriptionPaymentMethodRequest request,
-                string idempotencyKey = null,
-                CancellationToken cancellationToken = default);
-
-        /// <summary>
-        /// Get Subscription Item.
-        /// </summary>
-        /// <param name="subscriptionId">Required parameter: Subscription Id.</param>
-        /// <param name="itemId">Required parameter: Item id.</param>
-        /// <returns>Returns the Models.GetSubscriptionItemResponse response from the API call.</returns>
-        Models.GetSubscriptionItemResponse GetSubscriptionItem(
-                string subscriptionId,
-                string itemId);
-
-        /// <summary>
-        /// Get Subscription Item.
-        /// </summary>
-        /// <param name="subscriptionId">Required parameter: Subscription Id.</param>
-        /// <param name="itemId">Required parameter: Item id.</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetSubscriptionItemResponse response from the API call.</returns>
-        Task<Models.GetSubscriptionItemResponse> GetSubscriptionItemAsync(
-                string subscriptionId,
-                string itemId,
                 CancellationToken cancellationToken = default);
 
         /// <summary>
@@ -361,88 +130,6 @@ namespace PagarmeApiSDK.Standard.Controllers
                 DateTime? nextBillingUntil = null,
                 DateTime? createdSince = null,
                 DateTime? createdUntil = null,
-                CancellationToken cancellationToken = default);
-
-        /// <summary>
-        /// Cancels a subscription.
-        /// </summary>
-        /// <param name="subscriptionId">Required parameter: Subscription id.</param>
-        /// <param name="request">Optional parameter: Request for cancelling a subscription.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <returns>Returns the Models.GetSubscriptionResponse response from the API call.</returns>
-        Models.GetSubscriptionResponse CancelSubscription(
-                string subscriptionId,
-                Models.CreateCancelSubscriptionRequest request = null,
-                string idempotencyKey = null);
-
-        /// <summary>
-        /// Cancels a subscription.
-        /// </summary>
-        /// <param name="subscriptionId">Required parameter: Subscription id.</param>
-        /// <param name="request">Optional parameter: Request for cancelling a subscription.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetSubscriptionResponse response from the API call.</returns>
-        Task<Models.GetSubscriptionResponse> CancelSubscriptionAsync(
-                string subscriptionId,
-                Models.CreateCancelSubscriptionRequest request = null,
-                string idempotencyKey = null,
-                CancellationToken cancellationToken = default);
-
-        /// <summary>
-        /// Creates a increment.
-        /// </summary>
-        /// <param name="subscriptionId">Required parameter: Subscription id.</param>
-        /// <param name="request">Required parameter: Request for creating a increment.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <returns>Returns the Models.GetIncrementResponse response from the API call.</returns>
-        Models.GetIncrementResponse CreateIncrement(
-                string subscriptionId,
-                Models.CreateIncrementRequest request,
-                string idempotencyKey = null);
-
-        /// <summary>
-        /// Creates a increment.
-        /// </summary>
-        /// <param name="subscriptionId">Required parameter: Subscription id.</param>
-        /// <param name="request">Required parameter: Request for creating a increment.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetIncrementResponse response from the API call.</returns>
-        Task<Models.GetIncrementResponse> CreateIncrementAsync(
-                string subscriptionId,
-                Models.CreateIncrementRequest request,
-                string idempotencyKey = null,
-                CancellationToken cancellationToken = default);
-
-        /// <summary>
-        /// Creates a usage.
-        /// </summary>
-        /// <param name="subscriptionId">Required parameter: Subscription Id.</param>
-        /// <param name="itemId">Required parameter: Item id.</param>
-        /// <param name="body">Required parameter: Request for creating a usage.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <returns>Returns the Models.GetUsageResponse response from the API call.</returns>
-        Models.GetUsageResponse CreateUsage(
-                string subscriptionId,
-                string itemId,
-                Models.CreateUsageRequest body,
-                string idempotencyKey = null);
-
-        /// <summary>
-        /// Creates a usage.
-        /// </summary>
-        /// <param name="subscriptionId">Required parameter: Subscription Id.</param>
-        /// <param name="itemId">Required parameter: Item id.</param>
-        /// <param name="body">Required parameter: Request for creating a usage.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetUsageResponse response from the API call.</returns>
-        Task<Models.GetUsageResponse> CreateUsageAsync(
-                string subscriptionId,
-                string itemId,
-                Models.CreateUsageRequest body,
-                string idempotencyKey = null,
                 CancellationToken cancellationToken = default);
 
         /// <summary>
@@ -512,32 +199,6 @@ namespace PagarmeApiSDK.Standard.Controllers
                 CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// UpdateSubscriptionAffiliationId EndPoint.
-        /// </summary>
-        /// <param name="subscriptionId">Required parameter: Example: .</param>
-        /// <param name="request">Required parameter: Request for updating a subscription affiliation id.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <returns>Returns the Models.GetSubscriptionResponse response from the API call.</returns>
-        Models.GetSubscriptionResponse UpdateSubscriptionAffiliationId(
-                string subscriptionId,
-                Models.UpdateSubscriptionAffiliationIdRequest request,
-                string idempotencyKey = null);
-
-        /// <summary>
-        /// UpdateSubscriptionAffiliationId EndPoint.
-        /// </summary>
-        /// <param name="subscriptionId">Required parameter: Example: .</param>
-        /// <param name="request">Required parameter: Request for updating a subscription affiliation id.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetSubscriptionResponse response from the API call.</returns>
-        Task<Models.GetSubscriptionResponse> UpdateSubscriptionAffiliationIdAsync(
-                string subscriptionId,
-                Models.UpdateSubscriptionAffiliationIdRequest request,
-                string idempotencyKey = null,
-                CancellationToken cancellationToken = default);
-
-        /// <summary>
         /// Updates the metadata from a subscription.
         /// </summary>
         /// <param name="subscriptionId">Required parameter: The subscription id.</param>
@@ -590,29 +251,170 @@ namespace PagarmeApiSDK.Standard.Controllers
                 CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// GetSubscriptionCycles EndPoint.
+        /// Gets a subscription.
         /// </summary>
-        /// <param name="subscriptionId">Required parameter: Subscription Id.</param>
-        /// <param name="page">Required parameter: Page number.</param>
-        /// <param name="size">Required parameter: Page size.</param>
-        /// <returns>Returns the Models.ListCyclesResponse response from the API call.</returns>
-        Models.ListCyclesResponse GetSubscriptionCycles(
-                string subscriptionId,
-                string page,
-                string size);
+        /// <param name="subscriptionId">Required parameter: Subscription id.</param>
+        /// <returns>Returns the Models.GetSubscriptionResponse response from the API call.</returns>
+        Models.GetSubscriptionResponse GetSubscription(
+                string subscriptionId);
 
         /// <summary>
-        /// GetSubscriptionCycles EndPoint.
+        /// Gets a subscription.
+        /// </summary>
+        /// <param name="subscriptionId">Required parameter: Subscription id.</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetSubscriptionResponse response from the API call.</returns>
+        Task<Models.GetSubscriptionResponse> GetSubscriptionAsync(
+                string subscriptionId,
+                CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// UpdateLatestPeriodEndAt EndPoint.
+        /// </summary>
+        /// <param name="subscriptionId">Required parameter: Example: .</param>
+        /// <param name="request">Required parameter: Request for updating the end date of the current signature cycle.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <returns>Returns the Models.GetSubscriptionResponse response from the API call.</returns>
+        Models.GetSubscriptionResponse UpdateLatestPeriodEndAt(
+                string subscriptionId,
+                Models.UpdateCurrentCycleEndDateRequest request,
+                string idempotencyKey = null);
+
+        /// <summary>
+        /// UpdateLatestPeriodEndAt EndPoint.
+        /// </summary>
+        /// <param name="subscriptionId">Required parameter: Example: .</param>
+        /// <param name="request">Required parameter: Request for updating the end date of the current signature cycle.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetSubscriptionResponse response from the API call.</returns>
+        Task<Models.GetSubscriptionResponse> UpdateLatestPeriodEndAtAsync(
+                string subscriptionId,
+                Models.UpdateCurrentCycleEndDateRequest request,
+                string idempotencyKey = null,
+                CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// UpdateCurrentCycleStatus EndPoint.
         /// </summary>
         /// <param name="subscriptionId">Required parameter: Subscription Id.</param>
-        /// <param name="page">Required parameter: Page number.</param>
-        /// <param name="size">Required parameter: Page size.</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.ListCyclesResponse response from the API call.</returns>
-        Task<Models.ListCyclesResponse> GetSubscriptionCyclesAsync(
+        /// <param name="request">Required parameter: Request for updating the end date of the subscription current status.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        void UpdateCurrentCycleStatus(
                 string subscriptionId,
-                string page,
-                string size,
+                Models.UpdateCurrentCycleStatusRequest request,
+                string idempotencyKey = null);
+
+        /// <summary>
+        /// UpdateCurrentCycleStatus EndPoint.
+        /// </summary>
+        /// <param name="subscriptionId">Required parameter: Subscription Id.</param>
+        /// <param name="request">Required parameter: Request for updating the end date of the subscription current status.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the void response from the API call.</returns>
+        Task UpdateCurrentCycleStatusAsync(
+                string subscriptionId,
+                Models.UpdateCurrentCycleStatusRequest request,
+                string idempotencyKey = null,
+                CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Get Subscription Items.
+        /// </summary>
+        /// <param name="subscriptionId">Required parameter: The subscription id.</param>
+        /// <param name="page">Optional parameter: Page number.</param>
+        /// <param name="size">Optional parameter: Page size.</param>
+        /// <param name="name">Optional parameter: The item name.</param>
+        /// <param name="code">Optional parameter: Identification code in the client system.</param>
+        /// <param name="status">Optional parameter: The item statis.</param>
+        /// <param name="description">Optional parameter: The item description.</param>
+        /// <param name="createdSince">Optional parameter: Filter for item's creation date start range.</param>
+        /// <param name="createdUntil">Optional parameter: Filter for item's creation date end range.</param>
+        /// <returns>Returns the Models.ListSubscriptionItemsResponse response from the API call.</returns>
+        Models.ListSubscriptionItemsResponse GetSubscriptionItems(
+                string subscriptionId,
+                int? page = null,
+                int? size = null,
+                string name = null,
+                string code = null,
+                string status = null,
+                string description = null,
+                string createdSince = null,
+                string createdUntil = null);
+
+        /// <summary>
+        /// Get Subscription Items.
+        /// </summary>
+        /// <param name="subscriptionId">Required parameter: The subscription id.</param>
+        /// <param name="page">Optional parameter: Page number.</param>
+        /// <param name="size">Optional parameter: Page size.</param>
+        /// <param name="name">Optional parameter: The item name.</param>
+        /// <param name="code">Optional parameter: Identification code in the client system.</param>
+        /// <param name="status">Optional parameter: The item statis.</param>
+        /// <param name="description">Optional parameter: The item description.</param>
+        /// <param name="createdSince">Optional parameter: Filter for item's creation date start range.</param>
+        /// <param name="createdUntil">Optional parameter: Filter for item's creation date end range.</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.ListSubscriptionItemsResponse response from the API call.</returns>
+        Task<Models.ListSubscriptionItemsResponse> GetSubscriptionItemsAsync(
+                string subscriptionId,
+                int? page = null,
+                int? size = null,
+                string name = null,
+                string code = null,
+                string status = null,
+                string description = null,
+                string createdSince = null,
+                string createdUntil = null,
+                CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Get Subscription Item.
+        /// </summary>
+        /// <param name="subscriptionId">Required parameter: Subscription Id.</param>
+        /// <param name="itemId">Required parameter: Item id.</param>
+        /// <returns>Returns the Models.GetSubscriptionItemResponse response from the API call.</returns>
+        Models.GetSubscriptionItemResponse GetSubscriptionItem(
+                string subscriptionId,
+                string itemId);
+
+        /// <summary>
+        /// Get Subscription Item.
+        /// </summary>
+        /// <param name="subscriptionId">Required parameter: Subscription Id.</param>
+        /// <param name="itemId">Required parameter: Item id.</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetSubscriptionItemResponse response from the API call.</returns>
+        Task<Models.GetSubscriptionItemResponse> GetSubscriptionItemAsync(
+                string subscriptionId,
+                string itemId,
+                CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// UpdateSubscriptionAffiliationId EndPoint.
+        /// </summary>
+        /// <param name="subscriptionId">Required parameter: Example: .</param>
+        /// <param name="request">Required parameter: Request for updating a subscription affiliation id.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <returns>Returns the Models.GetSubscriptionResponse response from the API call.</returns>
+        Models.GetSubscriptionResponse UpdateSubscriptionAffiliationId(
+                string subscriptionId,
+                Models.UpdateSubscriptionAffiliationIdRequest request,
+                string idempotencyKey = null);
+
+        /// <summary>
+        /// UpdateSubscriptionAffiliationId EndPoint.
+        /// </summary>
+        /// <param name="subscriptionId">Required parameter: Example: .</param>
+        /// <param name="request">Required parameter: Request for updating a subscription affiliation id.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetSubscriptionResponse response from the API call.</returns>
+        Task<Models.GetSubscriptionResponse> UpdateSubscriptionAffiliationIdAsync(
+                string subscriptionId,
+                Models.UpdateSubscriptionAffiliationIdRequest request,
+                string idempotencyKey = null,
                 CancellationToken cancellationToken = default);
 
         /// <summary>
@@ -642,28 +444,204 @@ namespace PagarmeApiSDK.Standard.Controllers
                 CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Updates the billing date from a subscription.
+        /// Updates a subscription item.
         /// </summary>
-        /// <param name="subscriptionId">Required parameter: The subscription id.</param>
-        /// <param name="request">Required parameter: Request for updating the subscription billing date.</param>
+        /// <param name="subscriptionId">Required parameter: Subscription Id.</param>
+        /// <param name="itemId">Required parameter: Item id.</param>
+        /// <param name="body">Required parameter: Request for updating a subscription item.</param>
         /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <returns>Returns the Models.GetSubscriptionResponse response from the API call.</returns>
-        Models.GetSubscriptionResponse UpdateSubscriptionBillingDate(
+        /// <returns>Returns the Models.GetSubscriptionItemResponse response from the API call.</returns>
+        Models.GetSubscriptionItemResponse UpdateSubscriptionItem(
                 string subscriptionId,
-                Models.UpdateSubscriptionBillingDateRequest request,
+                string itemId,
+                Models.UpdateSubscriptionItemRequest body,
                 string idempotencyKey = null);
 
         /// <summary>
-        /// Updates the billing date from a subscription.
+        /// Updates a subscription item.
+        /// </summary>
+        /// <param name="subscriptionId">Required parameter: Subscription Id.</param>
+        /// <param name="itemId">Required parameter: Item id.</param>
+        /// <param name="body">Required parameter: Request for updating a subscription item.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetSubscriptionItemResponse response from the API call.</returns>
+        Task<Models.GetSubscriptionItemResponse> UpdateSubscriptionItemAsync(
+                string subscriptionId,
+                string itemId,
+                Models.UpdateSubscriptionItemRequest body,
+                string idempotencyKey = null,
+                CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Creates a new Subscription item.
+        /// </summary>
+        /// <param name="subscriptionId">Required parameter: Subscription id.</param>
+        /// <param name="request">Required parameter: Request for creating a subscription item.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <returns>Returns the Models.GetSubscriptionItemResponse response from the API call.</returns>
+        Models.GetSubscriptionItemResponse CreateSubscriptionItem(
+                string subscriptionId,
+                Models.CreateSubscriptionItemRequest request,
+                string idempotencyKey = null);
+
+        /// <summary>
+        /// Creates a new Subscription item.
+        /// </summary>
+        /// <param name="subscriptionId">Required parameter: Subscription id.</param>
+        /// <param name="request">Required parameter: Request for creating a subscription item.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetSubscriptionItemResponse response from the API call.</returns>
+        Task<Models.GetSubscriptionItemResponse> CreateSubscriptionItemAsync(
+                string subscriptionId,
+                Models.CreateSubscriptionItemRequest request,
+                string idempotencyKey = null,
+                CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Lists all usages from a subscription item.
         /// </summary>
         /// <param name="subscriptionId">Required parameter: The subscription id.</param>
-        /// <param name="request">Required parameter: Request for updating the subscription billing date.</param>
+        /// <param name="itemId">Required parameter: The subscription item id.</param>
+        /// <param name="page">Optional parameter: Page number.</param>
+        /// <param name="size">Optional parameter: Page size.</param>
+        /// <param name="code">Optional parameter: Identification code in the client system.</param>
+        /// <param name="mGroup">Optional parameter: Identification group in the client system.</param>
+        /// <param name="usedSince">Optional parameter: Example: .</param>
+        /// <param name="usedUntil">Optional parameter: Example: .</param>
+        /// <returns>Returns the Models.ListUsagesResponse response from the API call.</returns>
+        Models.ListUsagesResponse GetUsages(
+                string subscriptionId,
+                string itemId,
+                int? page = null,
+                int? size = null,
+                string code = null,
+                string mGroup = null,
+                DateTime? usedSince = null,
+                DateTime? usedUntil = null);
+
+        /// <summary>
+        /// Lists all usages from a subscription item.
+        /// </summary>
+        /// <param name="subscriptionId">Required parameter: The subscription id.</param>
+        /// <param name="itemId">Required parameter: The subscription item id.</param>
+        /// <param name="page">Optional parameter: Page number.</param>
+        /// <param name="size">Optional parameter: Page size.</param>
+        /// <param name="code">Optional parameter: Identification code in the client system.</param>
+        /// <param name="mGroup">Optional parameter: Identification group in the client system.</param>
+        /// <param name="usedSince">Optional parameter: Example: .</param>
+        /// <param name="usedUntil">Optional parameter: Example: .</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.ListUsagesResponse response from the API call.</returns>
+        Task<Models.ListUsagesResponse> GetUsagesAsync(
+                string subscriptionId,
+                string itemId,
+                int? page = null,
+                int? size = null,
+                string code = null,
+                string mGroup = null,
+                DateTime? usedSince = null,
+                DateTime? usedUntil = null,
+                CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Atualização do valor mínimo da assinatura.
+        /// </summary>
+        /// <param name="subscriptionId">Required parameter: Subscription Id.</param>
+        /// <param name="request">Required parameter: Request da requisição com o valor mínimo que será configurado.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <returns>Returns the Models.GetSubscriptionResponse response from the API call.</returns>
+        Models.GetSubscriptionResponse UpdateSubscriptionMiniumPrice(
+                string subscriptionId,
+                Models.UpdateSubscriptionMinimumPriceRequest request,
+                string idempotencyKey = null);
+
+        /// <summary>
+        /// Atualização do valor mínimo da assinatura.
+        /// </summary>
+        /// <param name="subscriptionId">Required parameter: Subscription Id.</param>
+        /// <param name="request">Required parameter: Request da requisição com o valor mínimo que será configurado.</param>
         /// <param name="idempotencyKey">Optional parameter: Example: .</param>
         /// <param name="cancellationToken"> cancellationToken. </param>
         /// <returns>Returns the Models.GetSubscriptionResponse response from the API call.</returns>
-        Task<Models.GetSubscriptionResponse> UpdateSubscriptionBillingDateAsync(
+        Task<Models.GetSubscriptionResponse> UpdateSubscriptionMiniumPriceAsync(
                 string subscriptionId,
-                Models.UpdateSubscriptionBillingDateRequest request,
+                Models.UpdateSubscriptionMinimumPriceRequest request,
+                string idempotencyKey = null,
+                CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// GetSubscriptionCycleById EndPoint.
+        /// </summary>
+        /// <param name="subscriptionId">Required parameter: The subscription id.</param>
+        /// <param name="cycleId">Required parameter: Example: .</param>
+        /// <returns>Returns the Models.GetPeriodResponse response from the API call.</returns>
+        Models.GetPeriodResponse GetSubscriptionCycleById(
+                string subscriptionId,
+                string cycleId);
+
+        /// <summary>
+        /// GetSubscriptionCycleById EndPoint.
+        /// </summary>
+        /// <param name="subscriptionId">Required parameter: The subscription id.</param>
+        /// <param name="cycleId">Required parameter: Example: .</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetPeriodResponse response from the API call.</returns>
+        Task<Models.GetPeriodResponse> GetSubscriptionCycleByIdAsync(
+                string subscriptionId,
+                string cycleId,
+                CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Create Usage.
+        /// </summary>
+        /// <param name="subscriptionId">Required parameter: Subscription id.</param>
+        /// <param name="itemId">Required parameter: Item id.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <returns>Returns the Models.GetUsageResponse response from the API call.</returns>
+        Models.GetUsageResponse CreateAnUsage(
+                string subscriptionId,
+                string itemId,
+                string idempotencyKey = null);
+
+        /// <summary>
+        /// Create Usage.
+        /// </summary>
+        /// <param name="subscriptionId">Required parameter: Subscription id.</param>
+        /// <param name="itemId">Required parameter: Item id.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetUsageResponse response from the API call.</returns>
+        Task<Models.GetUsageResponse> CreateAnUsageAsync(
+                string subscriptionId,
+                string itemId,
+                string idempotencyKey = null,
+                CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Cancels a subscription.
+        /// </summary>
+        /// <param name="subscriptionId">Required parameter: Subscription id.</param>
+        /// <param name="request">Optional parameter: Request for cancelling a subscription.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <returns>Returns the Models.GetSubscriptionResponse response from the API call.</returns>
+        Models.GetSubscriptionResponse CancelSubscription(
+                string subscriptionId,
+                Models.CreateCancelSubscriptionRequest request = null,
+                string idempotencyKey = null);
+
+        /// <summary>
+        /// Cancels a subscription.
+        /// </summary>
+        /// <param name="subscriptionId">Required parameter: Subscription id.</param>
+        /// <param name="request">Optional parameter: Request for cancelling a subscription.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetSubscriptionResponse response from the API call.</returns>
+        Task<Models.GetSubscriptionResponse> CancelSubscriptionAsync(
+                string subscriptionId,
+                Models.CreateCancelSubscriptionRequest request = null,
                 string idempotencyKey = null,
                 CancellationToken cancellationToken = default);
 
@@ -746,6 +724,222 @@ namespace PagarmeApiSDK.Standard.Controllers
                 CancellationToken cancellationToken = default);
 
         /// <summary>
+        /// Updates the credit card from a subscription.
+        /// </summary>
+        /// <param name="subscriptionId">Required parameter: Subscription id.</param>
+        /// <param name="request">Required parameter: Request for updating a card.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <returns>Returns the Models.GetSubscriptionResponse response from the API call.</returns>
+        Models.GetSubscriptionResponse UpdateSubscriptionCard(
+                string subscriptionId,
+                Models.UpdateSubscriptionCardRequest request,
+                string idempotencyKey = null);
+
+        /// <summary>
+        /// Updates the credit card from a subscription.
+        /// </summary>
+        /// <param name="subscriptionId">Required parameter: Subscription id.</param>
+        /// <param name="request">Required parameter: Request for updating a card.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetSubscriptionResponse response from the API call.</returns>
+        Task<Models.GetSubscriptionResponse> UpdateSubscriptionCardAsync(
+                string subscriptionId,
+                Models.UpdateSubscriptionCardRequest request,
+                string idempotencyKey = null,
+                CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Deletes a usage.
+        /// </summary>
+        /// <param name="subscriptionId">Required parameter: The subscription id.</param>
+        /// <param name="itemId">Required parameter: The subscription item id.</param>
+        /// <param name="usageId">Required parameter: The usage id.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <returns>Returns the Models.GetUsageResponse response from the API call.</returns>
+        Models.GetUsageResponse DeleteUsage(
+                string subscriptionId,
+                string itemId,
+                string usageId,
+                string idempotencyKey = null);
+
+        /// <summary>
+        /// Deletes a usage.
+        /// </summary>
+        /// <param name="subscriptionId">Required parameter: The subscription id.</param>
+        /// <param name="itemId">Required parameter: The subscription item id.</param>
+        /// <param name="usageId">Required parameter: The usage id.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetUsageResponse response from the API call.</returns>
+        Task<Models.GetUsageResponse> DeleteUsageAsync(
+                string subscriptionId,
+                string itemId,
+                string usageId,
+                string idempotencyKey = null,
+                CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Creates a discount.
+        /// </summary>
+        /// <param name="subscriptionId">Required parameter: Subscription id.</param>
+        /// <param name="request">Required parameter: Request for creating a discount.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <returns>Returns the Models.GetDiscountResponse response from the API call.</returns>
+        Models.GetDiscountResponse CreateDiscount(
+                string subscriptionId,
+                Models.CreateDiscountRequest request,
+                string idempotencyKey = null);
+
+        /// <summary>
+        /// Creates a discount.
+        /// </summary>
+        /// <param name="subscriptionId">Required parameter: Subscription id.</param>
+        /// <param name="request">Required parameter: Request for creating a discount.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetDiscountResponse response from the API call.</returns>
+        Task<Models.GetDiscountResponse> CreateDiscountAsync(
+                string subscriptionId,
+                Models.CreateDiscountRequest request,
+                string idempotencyKey = null,
+                CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Updates the payment method from a subscription.
+        /// </summary>
+        /// <param name="subscriptionId">Required parameter: Subscription id.</param>
+        /// <param name="request">Required parameter: Request for updating the paymentmethod from a subscription.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <returns>Returns the Models.GetSubscriptionResponse response from the API call.</returns>
+        Models.GetSubscriptionResponse UpdateSubscriptionPaymentMethod(
+                string subscriptionId,
+                Models.UpdateSubscriptionPaymentMethodRequest request,
+                string idempotencyKey = null);
+
+        /// <summary>
+        /// Updates the payment method from a subscription.
+        /// </summary>
+        /// <param name="subscriptionId">Required parameter: Subscription id.</param>
+        /// <param name="request">Required parameter: Request for updating the paymentmethod from a subscription.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetSubscriptionResponse response from the API call.</returns>
+        Task<Models.GetSubscriptionResponse> UpdateSubscriptionPaymentMethodAsync(
+                string subscriptionId,
+                Models.UpdateSubscriptionPaymentMethodRequest request,
+                string idempotencyKey = null,
+                CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Creates a increment.
+        /// </summary>
+        /// <param name="subscriptionId">Required parameter: Subscription id.</param>
+        /// <param name="request">Required parameter: Request for creating a increment.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <returns>Returns the Models.GetIncrementResponse response from the API call.</returns>
+        Models.GetIncrementResponse CreateIncrement(
+                string subscriptionId,
+                Models.CreateIncrementRequest request,
+                string idempotencyKey = null);
+
+        /// <summary>
+        /// Creates a increment.
+        /// </summary>
+        /// <param name="subscriptionId">Required parameter: Subscription id.</param>
+        /// <param name="request">Required parameter: Request for creating a increment.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetIncrementResponse response from the API call.</returns>
+        Task<Models.GetIncrementResponse> CreateIncrementAsync(
+                string subscriptionId,
+                Models.CreateIncrementRequest request,
+                string idempotencyKey = null,
+                CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Creates a usage.
+        /// </summary>
+        /// <param name="subscriptionId">Required parameter: Subscription Id.</param>
+        /// <param name="itemId">Required parameter: Item id.</param>
+        /// <param name="body">Required parameter: Request for creating a usage.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <returns>Returns the Models.GetUsageResponse response from the API call.</returns>
+        Models.GetUsageResponse CreateUsage(
+                string subscriptionId,
+                string itemId,
+                Models.CreateUsageRequest body,
+                string idempotencyKey = null);
+
+        /// <summary>
+        /// Creates a usage.
+        /// </summary>
+        /// <param name="subscriptionId">Required parameter: Subscription Id.</param>
+        /// <param name="itemId">Required parameter: Item id.</param>
+        /// <param name="body">Required parameter: Request for creating a usage.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetUsageResponse response from the API call.</returns>
+        Task<Models.GetUsageResponse> CreateUsageAsync(
+                string subscriptionId,
+                string itemId,
+                Models.CreateUsageRequest body,
+                string idempotencyKey = null,
+                CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// GetSubscriptionCycles EndPoint.
+        /// </summary>
+        /// <param name="subscriptionId">Required parameter: Subscription Id.</param>
+        /// <param name="page">Required parameter: Page number.</param>
+        /// <param name="size">Required parameter: Page size.</param>
+        /// <returns>Returns the Models.ListCyclesResponse response from the API call.</returns>
+        Models.ListCyclesResponse GetSubscriptionCycles(
+                string subscriptionId,
+                string page,
+                string size);
+
+        /// <summary>
+        /// GetSubscriptionCycles EndPoint.
+        /// </summary>
+        /// <param name="subscriptionId">Required parameter: Subscription Id.</param>
+        /// <param name="page">Required parameter: Page number.</param>
+        /// <param name="size">Required parameter: Page size.</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.ListCyclesResponse response from the API call.</returns>
+        Task<Models.ListCyclesResponse> GetSubscriptionCyclesAsync(
+                string subscriptionId,
+                string page,
+                string size,
+                CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Updates the billing date from a subscription.
+        /// </summary>
+        /// <param name="subscriptionId">Required parameter: The subscription id.</param>
+        /// <param name="request">Required parameter: Request for updating the subscription billing date.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <returns>Returns the Models.GetSubscriptionResponse response from the API call.</returns>
+        Models.GetSubscriptionResponse UpdateSubscriptionBillingDate(
+                string subscriptionId,
+                Models.UpdateSubscriptionBillingDateRequest request,
+                string idempotencyKey = null);
+
+        /// <summary>
+        /// Updates the billing date from a subscription.
+        /// </summary>
+        /// <param name="subscriptionId">Required parameter: The subscription id.</param>
+        /// <param name="request">Required parameter: Request for updating the subscription billing date.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetSubscriptionResponse response from the API call.</returns>
+        Task<Models.GetSubscriptionResponse> UpdateSubscriptionBillingDateAsync(
+                string subscriptionId,
+                Models.UpdateSubscriptionBillingDateRequest request,
+                string idempotencyKey = null,
+                CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// Updates the start at date from a subscription.
         /// </summary>
         /// <param name="subscriptionId">Required parameter: The subscription id.</param>
@@ -769,200 +963,6 @@ namespace PagarmeApiSDK.Standard.Controllers
                 string subscriptionId,
                 Models.UpdateSubscriptionStartAtRequest request,
                 string idempotencyKey = null,
-                CancellationToken cancellationToken = default);
-
-        /// <summary>
-        /// Updates a subscription item.
-        /// </summary>
-        /// <param name="subscriptionId">Required parameter: Subscription Id.</param>
-        /// <param name="itemId">Required parameter: Item id.</param>
-        /// <param name="body">Required parameter: Request for updating a subscription item.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <returns>Returns the Models.GetSubscriptionItemResponse response from the API call.</returns>
-        Models.GetSubscriptionItemResponse UpdateSubscriptionItem(
-                string subscriptionId,
-                string itemId,
-                Models.UpdateSubscriptionItemRequest body,
-                string idempotencyKey = null);
-
-        /// <summary>
-        /// Updates a subscription item.
-        /// </summary>
-        /// <param name="subscriptionId">Required parameter: Subscription Id.</param>
-        /// <param name="itemId">Required parameter: Item id.</param>
-        /// <param name="body">Required parameter: Request for updating a subscription item.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetSubscriptionItemResponse response from the API call.</returns>
-        Task<Models.GetSubscriptionItemResponse> UpdateSubscriptionItemAsync(
-                string subscriptionId,
-                string itemId,
-                Models.UpdateSubscriptionItemRequest body,
-                string idempotencyKey = null,
-                CancellationToken cancellationToken = default);
-
-        /// <summary>
-        /// Creates a new Subscription item.
-        /// </summary>
-        /// <param name="subscriptionId">Required parameter: Subscription id.</param>
-        /// <param name="request">Required parameter: Request for creating a subscription item.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <returns>Returns the Models.GetSubscriptionItemResponse response from the API call.</returns>
-        Models.GetSubscriptionItemResponse CreateSubscriptionItem(
-                string subscriptionId,
-                Models.CreateSubscriptionItemRequest request,
-                string idempotencyKey = null);
-
-        /// <summary>
-        /// Creates a new Subscription item.
-        /// </summary>
-        /// <param name="subscriptionId">Required parameter: Subscription id.</param>
-        /// <param name="request">Required parameter: Request for creating a subscription item.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetSubscriptionItemResponse response from the API call.</returns>
-        Task<Models.GetSubscriptionItemResponse> CreateSubscriptionItemAsync(
-                string subscriptionId,
-                Models.CreateSubscriptionItemRequest request,
-                string idempotencyKey = null,
-                CancellationToken cancellationToken = default);
-
-        /// <summary>
-        /// Gets a subscription.
-        /// </summary>
-        /// <param name="subscriptionId">Required parameter: Subscription id.</param>
-        /// <returns>Returns the Models.GetSubscriptionResponse response from the API call.</returns>
-        Models.GetSubscriptionResponse GetSubscription(
-                string subscriptionId);
-
-        /// <summary>
-        /// Gets a subscription.
-        /// </summary>
-        /// <param name="subscriptionId">Required parameter: Subscription id.</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetSubscriptionResponse response from the API call.</returns>
-        Task<Models.GetSubscriptionResponse> GetSubscriptionAsync(
-                string subscriptionId,
-                CancellationToken cancellationToken = default);
-
-        /// <summary>
-        /// Lists all usages from a subscription item.
-        /// </summary>
-        /// <param name="subscriptionId">Required parameter: The subscription id.</param>
-        /// <param name="itemId">Required parameter: The subscription item id.</param>
-        /// <param name="page">Optional parameter: Page number.</param>
-        /// <param name="size">Optional parameter: Page size.</param>
-        /// <param name="code">Optional parameter: Identification code in the client system.</param>
-        /// <param name="mGroup">Optional parameter: Identification group in the client system.</param>
-        /// <param name="usedSince">Optional parameter: Example: .</param>
-        /// <param name="usedUntil">Optional parameter: Example: .</param>
-        /// <returns>Returns the Models.ListUsagesResponse response from the API call.</returns>
-        Models.ListUsagesResponse GetUsages(
-                string subscriptionId,
-                string itemId,
-                int? page = null,
-                int? size = null,
-                string code = null,
-                string mGroup = null,
-                DateTime? usedSince = null,
-                DateTime? usedUntil = null);
-
-        /// <summary>
-        /// Lists all usages from a subscription item.
-        /// </summary>
-        /// <param name="subscriptionId">Required parameter: The subscription id.</param>
-        /// <param name="itemId">Required parameter: The subscription item id.</param>
-        /// <param name="page">Optional parameter: Page number.</param>
-        /// <param name="size">Optional parameter: Page size.</param>
-        /// <param name="code">Optional parameter: Identification code in the client system.</param>
-        /// <param name="mGroup">Optional parameter: Identification group in the client system.</param>
-        /// <param name="usedSince">Optional parameter: Example: .</param>
-        /// <param name="usedUntil">Optional parameter: Example: .</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.ListUsagesResponse response from the API call.</returns>
-        Task<Models.ListUsagesResponse> GetUsagesAsync(
-                string subscriptionId,
-                string itemId,
-                int? page = null,
-                int? size = null,
-                string code = null,
-                string mGroup = null,
-                DateTime? usedSince = null,
-                DateTime? usedUntil = null,
-                CancellationToken cancellationToken = default);
-
-        /// <summary>
-        /// UpdateLatestPeriodEndAt EndPoint.
-        /// </summary>
-        /// <param name="subscriptionId">Required parameter: Example: .</param>
-        /// <param name="request">Required parameter: Request for updating the end date of the current signature cycle.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <returns>Returns the Models.GetSubscriptionResponse response from the API call.</returns>
-        Models.GetSubscriptionResponse UpdateLatestPeriodEndAt(
-                string subscriptionId,
-                Models.UpdateCurrentCycleEndDateRequest request,
-                string idempotencyKey = null);
-
-        /// <summary>
-        /// UpdateLatestPeriodEndAt EndPoint.
-        /// </summary>
-        /// <param name="subscriptionId">Required parameter: Example: .</param>
-        /// <param name="request">Required parameter: Request for updating the end date of the current signature cycle.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetSubscriptionResponse response from the API call.</returns>
-        Task<Models.GetSubscriptionResponse> UpdateLatestPeriodEndAtAsync(
-                string subscriptionId,
-                Models.UpdateCurrentCycleEndDateRequest request,
-                string idempotencyKey = null,
-                CancellationToken cancellationToken = default);
-
-        /// <summary>
-        /// Atualização do valor mínimo da assinatura.
-        /// </summary>
-        /// <param name="subscriptionId">Required parameter: Subscription Id.</param>
-        /// <param name="request">Required parameter: Request da requisição com o valor mínimo que será configurado.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <returns>Returns the Models.GetSubscriptionResponse response from the API call.</returns>
-        Models.GetSubscriptionResponse UpdateSubscriptionMiniumPrice(
-                string subscriptionId,
-                Models.UpdateSubscriptionMinimumPriceRequest request,
-                string idempotencyKey = null);
-
-        /// <summary>
-        /// Atualização do valor mínimo da assinatura.
-        /// </summary>
-        /// <param name="subscriptionId">Required parameter: Subscription Id.</param>
-        /// <param name="request">Required parameter: Request da requisição com o valor mínimo que será configurado.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetSubscriptionResponse response from the API call.</returns>
-        Task<Models.GetSubscriptionResponse> UpdateSubscriptionMiniumPriceAsync(
-                string subscriptionId,
-                Models.UpdateSubscriptionMinimumPriceRequest request,
-                string idempotencyKey = null,
-                CancellationToken cancellationToken = default);
-
-        /// <summary>
-        /// GetSubscriptionCycleById EndPoint.
-        /// </summary>
-        /// <param name="subscriptionId">Required parameter: The subscription id.</param>
-        /// <param name="cycleId">Required parameter: Example: .</param>
-        /// <returns>Returns the Models.GetPeriodResponse response from the API call.</returns>
-        Models.GetPeriodResponse GetSubscriptionCycleById(
-                string subscriptionId,
-                string cycleId);
-
-        /// <summary>
-        /// GetSubscriptionCycleById EndPoint.
-        /// </summary>
-        /// <param name="subscriptionId">Required parameter: The subscription id.</param>
-        /// <param name="cycleId">Required parameter: Example: .</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetPeriodResponse response from the API call.</returns>
-        Task<Models.GetPeriodResponse> GetSubscriptionCycleByIdAsync(
-                string subscriptionId,
-                string cycleId,
                 CancellationToken cancellationToken = default);
 
         /// <summary>

--- a/PagarmeApiSDK.Standard/Controllers/ITransfersController.cs
+++ b/PagarmeApiSDK.Standard/Controllers/ITransfersController.cs
@@ -23,6 +23,19 @@ namespace PagarmeApiSDK.Standard.Controllers
     public interface ITransfersController
     {
         /// <summary>
+        /// Gets all transfers.
+        /// </summary>
+        /// <returns>Returns the Models.ListTransfers response from the API call.</returns>
+        Models.ListTransfers GetTransfers();
+
+        /// <summary>
+        /// Gets all transfers.
+        /// </summary>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.ListTransfers response from the API call.</returns>
+        Task<Models.ListTransfers> GetTransfersAsync(CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// GetTransferById EndPoint.
         /// </summary>
         /// <param name="transferId">Required parameter: Example: .</param>
@@ -57,18 +70,5 @@ namespace PagarmeApiSDK.Standard.Controllers
         Task<Models.GetTransfer> CreateTransferAsync(
                 Models.CreateTransfer request,
                 CancellationToken cancellationToken = default);
-
-        /// <summary>
-        /// Gets all transfers.
-        /// </summary>
-        /// <returns>Returns the Models.ListTransfers response from the API call.</returns>
-        Models.ListTransfers GetTransfers();
-
-        /// <summary>
-        /// Gets all transfers.
-        /// </summary>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.ListTransfers response from the API call.</returns>
-        Task<Models.ListTransfers> GetTransfersAsync(CancellationToken cancellationToken = default);
     }
 }

--- a/PagarmeApiSDK.Standard/Controllers/InvoicesController.cs
+++ b/PagarmeApiSDK.Standard/Controllers/InvoicesController.cs
@@ -37,198 +37,6 @@ namespace PagarmeApiSDK.Standard.Controllers
         }
 
         /// <summary>
-        /// Updates the metadata from an invoice.
-        /// </summary>
-        /// <param name="invoiceId">Required parameter: The invoice id.</param>
-        /// <param name="request">Required parameter: Request for updating the invoice metadata.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <returns>Returns the Models.GetInvoiceResponse response from the API call.</returns>
-        public Models.GetInvoiceResponse UpdateInvoiceMetadata(
-                string invoiceId,
-                Models.UpdateMetadataRequest request,
-                string idempotencyKey = null)
-        {
-            Task<Models.GetInvoiceResponse> t = this.UpdateInvoiceMetadataAsync(invoiceId, request, idempotencyKey);
-            ApiHelper.RunTaskSynchronously(t);
-            return t.Result;
-        }
-
-        /// <summary>
-        /// Updates the metadata from an invoice.
-        /// </summary>
-        /// <param name="invoiceId">Required parameter: The invoice id.</param>
-        /// <param name="request">Required parameter: Request for updating the invoice metadata.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetInvoiceResponse response from the API call.</returns>
-        public async Task<Models.GetInvoiceResponse> UpdateInvoiceMetadataAsync(
-                string invoiceId,
-                Models.UpdateMetadataRequest request,
-                string idempotencyKey = null,
-                CancellationToken cancellationToken = default)
-        {
-            // the base uri for api requests.
-            string baseUri = this.Config.GetBaseUri();
-
-            // prepare query string for API call.
-            StringBuilder queryBuilder = new StringBuilder(baseUri);
-            queryBuilder.Append("/invoices/{invoice_id}/metadata");
-
-            // process optional template parameters.
-            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
-            {
-                { "invoice_id", invoiceId },
-            });
-
-            // append request with appropriate headers and parameters
-            var headers = new Dictionary<string, string>()
-            {
-                { "user-agent", this.UserAgent },
-                { "accept", "application/json" },
-                { "content-type", "application/json; charset=utf-8" },
-                { "idempotency-key", idempotencyKey },
-            };
-
-            // append body params.
-            var bodyText = ApiHelper.JsonSerialize(request);
-
-            // prepare the API call request to fetch the response.
-            HttpRequest httpRequest = this.GetClientInstance().PatchBody(queryBuilder.ToString(), headers, bodyText);
-
-            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
-
-            // invoke request and get response.
-            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
-            HttpContext context = new HttpContext(httpRequest, response);
-
-            // handle errors defined at the API level.
-            this.ValidateResponse(response, context);
-
-            return ApiHelper.JsonDeserialize<Models.GetInvoiceResponse>(response.Body);
-        }
-
-        /// <summary>
-        /// GetPartialInvoice EndPoint.
-        /// </summary>
-        /// <param name="subscriptionId">Required parameter: Subscription Id.</param>
-        /// <returns>Returns the Models.GetInvoiceResponse response from the API call.</returns>
-        public Models.GetInvoiceResponse GetPartialInvoice(
-                string subscriptionId)
-        {
-            Task<Models.GetInvoiceResponse> t = this.GetPartialInvoiceAsync(subscriptionId);
-            ApiHelper.RunTaskSynchronously(t);
-            return t.Result;
-        }
-
-        /// <summary>
-        /// GetPartialInvoice EndPoint.
-        /// </summary>
-        /// <param name="subscriptionId">Required parameter: Subscription Id.</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetInvoiceResponse response from the API call.</returns>
-        public async Task<Models.GetInvoiceResponse> GetPartialInvoiceAsync(
-                string subscriptionId,
-                CancellationToken cancellationToken = default)
-        {
-            // the base uri for api requests.
-            string baseUri = this.Config.GetBaseUri();
-
-            // prepare query string for API call.
-            StringBuilder queryBuilder = new StringBuilder(baseUri);
-            queryBuilder.Append("/subscriptions/{subscription_id}/partial-invoice");
-
-            // process optional template parameters.
-            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
-            {
-                { "subscription_id", subscriptionId },
-            });
-
-            // append request with appropriate headers and parameters
-            var headers = new Dictionary<string, string>()
-            {
-                { "user-agent", this.UserAgent },
-                { "accept", "application/json" },
-            };
-
-            // prepare the API call request to fetch the response.
-            HttpRequest httpRequest = this.GetClientInstance().Get(queryBuilder.ToString(), headers);
-
-            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
-
-            // invoke request and get response.
-            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
-            HttpContext context = new HttpContext(httpRequest, response);
-
-            // handle errors defined at the API level.
-            this.ValidateResponse(response, context);
-
-            return ApiHelper.JsonDeserialize<Models.GetInvoiceResponse>(response.Body);
-        }
-
-        /// <summary>
-        /// Cancels an invoice.
-        /// </summary>
-        /// <param name="invoiceId">Required parameter: Invoice id.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <returns>Returns the Models.GetInvoiceResponse response from the API call.</returns>
-        public Models.GetInvoiceResponse CancelInvoice(
-                string invoiceId,
-                string idempotencyKey = null)
-        {
-            Task<Models.GetInvoiceResponse> t = this.CancelInvoiceAsync(invoiceId, idempotencyKey);
-            ApiHelper.RunTaskSynchronously(t);
-            return t.Result;
-        }
-
-        /// <summary>
-        /// Cancels an invoice.
-        /// </summary>
-        /// <param name="invoiceId">Required parameter: Invoice id.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetInvoiceResponse response from the API call.</returns>
-        public async Task<Models.GetInvoiceResponse> CancelInvoiceAsync(
-                string invoiceId,
-                string idempotencyKey = null,
-                CancellationToken cancellationToken = default)
-        {
-            // the base uri for api requests.
-            string baseUri = this.Config.GetBaseUri();
-
-            // prepare query string for API call.
-            StringBuilder queryBuilder = new StringBuilder(baseUri);
-            queryBuilder.Append("/invoices/{invoice_id}");
-
-            // process optional template parameters.
-            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
-            {
-                { "invoice_id", invoiceId },
-            });
-
-            // append request with appropriate headers and parameters
-            var headers = new Dictionary<string, string>()
-            {
-                { "user-agent", this.UserAgent },
-                { "accept", "application/json" },
-                { "idempotency-key", idempotencyKey },
-            };
-
-            // prepare the API call request to fetch the response.
-            HttpRequest httpRequest = this.GetClientInstance().Delete(queryBuilder.ToString(), headers, null);
-
-            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
-
-            // invoke request and get response.
-            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
-            HttpContext context = new HttpContext(httpRequest, response);
-
-            // handle errors defined at the API level.
-            this.ValidateResponse(response, context);
-
-            return ApiHelper.JsonDeserialize<Models.GetInvoiceResponse>(response.Body);
-        }
-
-        /// <summary>
         /// Create an Invoice.
         /// </summary>
         /// <param name="subscriptionId">Required parameter: Subscription Id.</param>
@@ -413,26 +221,30 @@ namespace PagarmeApiSDK.Standard.Controllers
         }
 
         /// <summary>
-        /// Gets an invoice.
+        /// Cancels an invoice.
         /// </summary>
-        /// <param name="invoiceId">Required parameter: Invoice Id.</param>
+        /// <param name="invoiceId">Required parameter: Invoice id.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
         /// <returns>Returns the Models.GetInvoiceResponse response from the API call.</returns>
-        public Models.GetInvoiceResponse GetInvoice(
-                string invoiceId)
+        public Models.GetInvoiceResponse CancelInvoice(
+                string invoiceId,
+                string idempotencyKey = null)
         {
-            Task<Models.GetInvoiceResponse> t = this.GetInvoiceAsync(invoiceId);
+            Task<Models.GetInvoiceResponse> t = this.CancelInvoiceAsync(invoiceId, idempotencyKey);
             ApiHelper.RunTaskSynchronously(t);
             return t.Result;
         }
 
         /// <summary>
-        /// Gets an invoice.
+        /// Cancels an invoice.
         /// </summary>
-        /// <param name="invoiceId">Required parameter: Invoice Id.</param>
+        /// <param name="invoiceId">Required parameter: Invoice id.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
         /// <param name="cancellationToken"> cancellationToken. </param>
         /// <returns>Returns the Models.GetInvoiceResponse response from the API call.</returns>
-        public async Task<Models.GetInvoiceResponse> GetInvoiceAsync(
+        public async Task<Models.GetInvoiceResponse> CancelInvoiceAsync(
                 string invoiceId,
+                string idempotencyKey = null,
                 CancellationToken cancellationToken = default)
         {
             // the base uri for api requests.
@@ -446,6 +258,136 @@ namespace PagarmeApiSDK.Standard.Controllers
             ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
             {
                 { "invoice_id", invoiceId },
+            });
+
+            // append request with appropriate headers and parameters
+            var headers = new Dictionary<string, string>()
+            {
+                { "user-agent", this.UserAgent },
+                { "accept", "application/json" },
+                { "idempotency-key", idempotencyKey },
+            };
+
+            // prepare the API call request to fetch the response.
+            HttpRequest httpRequest = this.GetClientInstance().Delete(queryBuilder.ToString(), headers, null);
+
+            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
+
+            // invoke request and get response.
+            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+            HttpContext context = new HttpContext(httpRequest, response);
+
+            // handle errors defined at the API level.
+            this.ValidateResponse(response, context);
+
+            return ApiHelper.JsonDeserialize<Models.GetInvoiceResponse>(response.Body);
+        }
+
+        /// <summary>
+        /// Updates the metadata from an invoice.
+        /// </summary>
+        /// <param name="invoiceId">Required parameter: The invoice id.</param>
+        /// <param name="request">Required parameter: Request for updating the invoice metadata.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <returns>Returns the Models.GetInvoiceResponse response from the API call.</returns>
+        public Models.GetInvoiceResponse UpdateInvoiceMetadata(
+                string invoiceId,
+                Models.UpdateMetadataRequest request,
+                string idempotencyKey = null)
+        {
+            Task<Models.GetInvoiceResponse> t = this.UpdateInvoiceMetadataAsync(invoiceId, request, idempotencyKey);
+            ApiHelper.RunTaskSynchronously(t);
+            return t.Result;
+        }
+
+        /// <summary>
+        /// Updates the metadata from an invoice.
+        /// </summary>
+        /// <param name="invoiceId">Required parameter: The invoice id.</param>
+        /// <param name="request">Required parameter: Request for updating the invoice metadata.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetInvoiceResponse response from the API call.</returns>
+        public async Task<Models.GetInvoiceResponse> UpdateInvoiceMetadataAsync(
+                string invoiceId,
+                Models.UpdateMetadataRequest request,
+                string idempotencyKey = null,
+                CancellationToken cancellationToken = default)
+        {
+            // the base uri for api requests.
+            string baseUri = this.Config.GetBaseUri();
+
+            // prepare query string for API call.
+            StringBuilder queryBuilder = new StringBuilder(baseUri);
+            queryBuilder.Append("/invoices/{invoice_id}/metadata");
+
+            // process optional template parameters.
+            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
+            {
+                { "invoice_id", invoiceId },
+            });
+
+            // append request with appropriate headers and parameters
+            var headers = new Dictionary<string, string>()
+            {
+                { "user-agent", this.UserAgent },
+                { "accept", "application/json" },
+                { "content-type", "application/json; charset=utf-8" },
+                { "idempotency-key", idempotencyKey },
+            };
+
+            // append body params.
+            var bodyText = ApiHelper.JsonSerialize(request);
+
+            // prepare the API call request to fetch the response.
+            HttpRequest httpRequest = this.GetClientInstance().PatchBody(queryBuilder.ToString(), headers, bodyText);
+
+            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
+
+            // invoke request and get response.
+            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+            HttpContext context = new HttpContext(httpRequest, response);
+
+            // handle errors defined at the API level.
+            this.ValidateResponse(response, context);
+
+            return ApiHelper.JsonDeserialize<Models.GetInvoiceResponse>(response.Body);
+        }
+
+        /// <summary>
+        /// GetPartialInvoice EndPoint.
+        /// </summary>
+        /// <param name="subscriptionId">Required parameter: Subscription Id.</param>
+        /// <returns>Returns the Models.GetInvoiceResponse response from the API call.</returns>
+        public Models.GetInvoiceResponse GetPartialInvoice(
+                string subscriptionId)
+        {
+            Task<Models.GetInvoiceResponse> t = this.GetPartialInvoiceAsync(subscriptionId);
+            ApiHelper.RunTaskSynchronously(t);
+            return t.Result;
+        }
+
+        /// <summary>
+        /// GetPartialInvoice EndPoint.
+        /// </summary>
+        /// <param name="subscriptionId">Required parameter: Subscription Id.</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetInvoiceResponse response from the API call.</returns>
+        public async Task<Models.GetInvoiceResponse> GetPartialInvoiceAsync(
+                string subscriptionId,
+                CancellationToken cancellationToken = default)
+        {
+            // the base uri for api requests.
+            string baseUri = this.Config.GetBaseUri();
+
+            // prepare query string for API call.
+            StringBuilder queryBuilder = new StringBuilder(baseUri);
+            queryBuilder.Append("/subscriptions/{subscription_id}/partial-invoice");
+
+            // process optional template parameters.
+            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
+            {
+                { "subscription_id", subscriptionId },
             });
 
             // append request with appropriate headers and parameters
@@ -528,6 +470,64 @@ namespace PagarmeApiSDK.Standard.Controllers
 
             // prepare the API call request to fetch the response.
             HttpRequest httpRequest = this.GetClientInstance().PatchBody(queryBuilder.ToString(), headers, bodyText);
+
+            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
+
+            // invoke request and get response.
+            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+            HttpContext context = new HttpContext(httpRequest, response);
+
+            // handle errors defined at the API level.
+            this.ValidateResponse(response, context);
+
+            return ApiHelper.JsonDeserialize<Models.GetInvoiceResponse>(response.Body);
+        }
+
+        /// <summary>
+        /// Gets an invoice.
+        /// </summary>
+        /// <param name="invoiceId">Required parameter: Invoice Id.</param>
+        /// <returns>Returns the Models.GetInvoiceResponse response from the API call.</returns>
+        public Models.GetInvoiceResponse GetInvoice(
+                string invoiceId)
+        {
+            Task<Models.GetInvoiceResponse> t = this.GetInvoiceAsync(invoiceId);
+            ApiHelper.RunTaskSynchronously(t);
+            return t.Result;
+        }
+
+        /// <summary>
+        /// Gets an invoice.
+        /// </summary>
+        /// <param name="invoiceId">Required parameter: Invoice Id.</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetInvoiceResponse response from the API call.</returns>
+        public async Task<Models.GetInvoiceResponse> GetInvoiceAsync(
+                string invoiceId,
+                CancellationToken cancellationToken = default)
+        {
+            // the base uri for api requests.
+            string baseUri = this.Config.GetBaseUri();
+
+            // prepare query string for API call.
+            StringBuilder queryBuilder = new StringBuilder(baseUri);
+            queryBuilder.Append("/invoices/{invoice_id}");
+
+            // process optional template parameters.
+            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
+            {
+                { "invoice_id", invoiceId },
+            });
+
+            // append request with appropriate headers and parameters
+            var headers = new Dictionary<string, string>()
+            {
+                { "user-agent", this.UserAgent },
+                { "accept", "application/json" },
+            };
+
+            // prepare the API call request to fetch the response.
+            HttpRequest httpRequest = this.GetClientInstance().Get(queryBuilder.ToString(), headers);
 
             httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
 

--- a/PagarmeApiSDK.Standard/Controllers/OrdersController.cs
+++ b/PagarmeApiSDK.Standard/Controllers/OrdersController.cs
@@ -125,6 +125,259 @@ namespace PagarmeApiSDK.Standard.Controllers
         }
 
         /// <summary>
+        /// GetOrderItem EndPoint.
+        /// </summary>
+        /// <param name="orderId">Required parameter: Order Id.</param>
+        /// <param name="itemId">Required parameter: Item Id.</param>
+        /// <returns>Returns the Models.GetOrderItemResponse response from the API call.</returns>
+        public Models.GetOrderItemResponse GetOrderItem(
+                string orderId,
+                string itemId)
+        {
+            Task<Models.GetOrderItemResponse> t = this.GetOrderItemAsync(orderId, itemId);
+            ApiHelper.RunTaskSynchronously(t);
+            return t.Result;
+        }
+
+        /// <summary>
+        /// GetOrderItem EndPoint.
+        /// </summary>
+        /// <param name="orderId">Required parameter: Order Id.</param>
+        /// <param name="itemId">Required parameter: Item Id.</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetOrderItemResponse response from the API call.</returns>
+        public async Task<Models.GetOrderItemResponse> GetOrderItemAsync(
+                string orderId,
+                string itemId,
+                CancellationToken cancellationToken = default)
+        {
+            // the base uri for api requests.
+            string baseUri = this.Config.GetBaseUri();
+
+            // prepare query string for API call.
+            StringBuilder queryBuilder = new StringBuilder(baseUri);
+            queryBuilder.Append("/orders/{orderId}/items/{itemId}");
+
+            // process optional template parameters.
+            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
+            {
+                { "orderId", orderId },
+                { "itemId", itemId },
+            });
+
+            // append request with appropriate headers and parameters
+            var headers = new Dictionary<string, string>()
+            {
+                { "user-agent", this.UserAgent },
+                { "accept", "application/json" },
+            };
+
+            // prepare the API call request to fetch the response.
+            HttpRequest httpRequest = this.GetClientInstance().Get(queryBuilder.ToString(), headers);
+
+            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
+
+            // invoke request and get response.
+            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+            HttpContext context = new HttpContext(httpRequest, response);
+
+            // handle errors defined at the API level.
+            this.ValidateResponse(response, context);
+
+            return ApiHelper.JsonDeserialize<Models.GetOrderItemResponse>(response.Body);
+        }
+
+        /// <summary>
+        /// Gets an order.
+        /// </summary>
+        /// <param name="orderId">Required parameter: Order id.</param>
+        /// <returns>Returns the Models.GetOrderResponse response from the API call.</returns>
+        public Models.GetOrderResponse GetOrder(
+                string orderId)
+        {
+            Task<Models.GetOrderResponse> t = this.GetOrderAsync(orderId);
+            ApiHelper.RunTaskSynchronously(t);
+            return t.Result;
+        }
+
+        /// <summary>
+        /// Gets an order.
+        /// </summary>
+        /// <param name="orderId">Required parameter: Order id.</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetOrderResponse response from the API call.</returns>
+        public async Task<Models.GetOrderResponse> GetOrderAsync(
+                string orderId,
+                CancellationToken cancellationToken = default)
+        {
+            // the base uri for api requests.
+            string baseUri = this.Config.GetBaseUri();
+
+            // prepare query string for API call.
+            StringBuilder queryBuilder = new StringBuilder(baseUri);
+            queryBuilder.Append("/orders/{order_id}");
+
+            // process optional template parameters.
+            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
+            {
+                { "order_id", orderId },
+            });
+
+            // append request with appropriate headers and parameters
+            var headers = new Dictionary<string, string>()
+            {
+                { "user-agent", this.UserAgent },
+                { "accept", "application/json" },
+            };
+
+            // prepare the API call request to fetch the response.
+            HttpRequest httpRequest = this.GetClientInstance().Get(queryBuilder.ToString(), headers);
+
+            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
+
+            // invoke request and get response.
+            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+            HttpContext context = new HttpContext(httpRequest, response);
+
+            // handle errors defined at the API level.
+            this.ValidateResponse(response, context);
+
+            return ApiHelper.JsonDeserialize<Models.GetOrderResponse>(response.Body);
+        }
+
+        /// <summary>
+        /// CloseOrder EndPoint.
+        /// </summary>
+        /// <param name="id">Required parameter: Order Id.</param>
+        /// <param name="request">Required parameter: Update Order Model.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <returns>Returns the Models.GetOrderResponse response from the API call.</returns>
+        public Models.GetOrderResponse CloseOrder(
+                string id,
+                Models.UpdateOrderStatusRequest request,
+                string idempotencyKey = null)
+        {
+            Task<Models.GetOrderResponse> t = this.CloseOrderAsync(id, request, idempotencyKey);
+            ApiHelper.RunTaskSynchronously(t);
+            return t.Result;
+        }
+
+        /// <summary>
+        /// CloseOrder EndPoint.
+        /// </summary>
+        /// <param name="id">Required parameter: Order Id.</param>
+        /// <param name="request">Required parameter: Update Order Model.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetOrderResponse response from the API call.</returns>
+        public async Task<Models.GetOrderResponse> CloseOrderAsync(
+                string id,
+                Models.UpdateOrderStatusRequest request,
+                string idempotencyKey = null,
+                CancellationToken cancellationToken = default)
+        {
+            // the base uri for api requests.
+            string baseUri = this.Config.GetBaseUri();
+
+            // prepare query string for API call.
+            StringBuilder queryBuilder = new StringBuilder(baseUri);
+            queryBuilder.Append("/orders/{id}/closed");
+
+            // process optional template parameters.
+            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
+            {
+                { "id", id },
+            });
+
+            // append request with appropriate headers and parameters
+            var headers = new Dictionary<string, string>()
+            {
+                { "user-agent", this.UserAgent },
+                { "accept", "application/json" },
+                { "content-type", "application/json; charset=utf-8" },
+                { "idempotency-key", idempotencyKey },
+            };
+
+            // append body params.
+            var bodyText = ApiHelper.JsonSerialize(request);
+
+            // prepare the API call request to fetch the response.
+            HttpRequest httpRequest = this.GetClientInstance().PatchBody(queryBuilder.ToString(), headers, bodyText);
+
+            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
+
+            // invoke request and get response.
+            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+            HttpContext context = new HttpContext(httpRequest, response);
+
+            // handle errors defined at the API level.
+            this.ValidateResponse(response, context);
+
+            return ApiHelper.JsonDeserialize<Models.GetOrderResponse>(response.Body);
+        }
+
+        /// <summary>
+        /// Creates a new Order.
+        /// </summary>
+        /// <param name="body">Required parameter: Request for creating an order.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <returns>Returns the Models.GetOrderResponse response from the API call.</returns>
+        public Models.GetOrderResponse CreateOrder(
+                Models.CreateOrderRequest body,
+                string idempotencyKey = null)
+        {
+            Task<Models.GetOrderResponse> t = this.CreateOrderAsync(body, idempotencyKey);
+            ApiHelper.RunTaskSynchronously(t);
+            return t.Result;
+        }
+
+        /// <summary>
+        /// Creates a new Order.
+        /// </summary>
+        /// <param name="body">Required parameter: Request for creating an order.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetOrderResponse response from the API call.</returns>
+        public async Task<Models.GetOrderResponse> CreateOrderAsync(
+                Models.CreateOrderRequest body,
+                string idempotencyKey = null,
+                CancellationToken cancellationToken = default)
+        {
+            // the base uri for api requests.
+            string baseUri = this.Config.GetBaseUri();
+
+            // prepare query string for API call.
+            StringBuilder queryBuilder = new StringBuilder(baseUri);
+            queryBuilder.Append("/orders");
+
+            // append request with appropriate headers and parameters
+            var headers = new Dictionary<string, string>()
+            {
+                { "user-agent", this.UserAgent },
+                { "accept", "application/json" },
+                { "content-type", "application/json; charset=utf-8" },
+                { "idempotency-key", idempotencyKey },
+            };
+
+            // append body params.
+            var bodyText = ApiHelper.JsonSerialize(body);
+
+            // prepare the API call request to fetch the response.
+            HttpRequest httpRequest = this.GetClientInstance().PostBody(queryBuilder.ToString(), headers, bodyText);
+
+            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
+
+            // invoke request and get response.
+            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+            HttpContext context = new HttpContext(httpRequest, response);
+
+            // handle errors defined at the API level.
+            this.ValidateResponse(response, context);
+
+            return ApiHelper.JsonDeserialize<Models.GetOrderResponse>(response.Body);
+        }
+
+        /// <summary>
         /// UpdateOrderItem EndPoint.
         /// </summary>
         /// <param name="orderId">Required parameter: Order Id.</param>
@@ -264,340 +517,6 @@ namespace PagarmeApiSDK.Standard.Controllers
         }
 
         /// <summary>
-        /// DeleteOrderItem EndPoint.
-        /// </summary>
-        /// <param name="orderId">Required parameter: Order Id.</param>
-        /// <param name="itemId">Required parameter: Item Id.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <returns>Returns the Models.GetOrderItemResponse response from the API call.</returns>
-        public Models.GetOrderItemResponse DeleteOrderItem(
-                string orderId,
-                string itemId,
-                string idempotencyKey = null)
-        {
-            Task<Models.GetOrderItemResponse> t = this.DeleteOrderItemAsync(orderId, itemId, idempotencyKey);
-            ApiHelper.RunTaskSynchronously(t);
-            return t.Result;
-        }
-
-        /// <summary>
-        /// DeleteOrderItem EndPoint.
-        /// </summary>
-        /// <param name="orderId">Required parameter: Order Id.</param>
-        /// <param name="itemId">Required parameter: Item Id.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetOrderItemResponse response from the API call.</returns>
-        public async Task<Models.GetOrderItemResponse> DeleteOrderItemAsync(
-                string orderId,
-                string itemId,
-                string idempotencyKey = null,
-                CancellationToken cancellationToken = default)
-        {
-            // the base uri for api requests.
-            string baseUri = this.Config.GetBaseUri();
-
-            // prepare query string for API call.
-            StringBuilder queryBuilder = new StringBuilder(baseUri);
-            queryBuilder.Append("/orders/{orderId}/items/{itemId}");
-
-            // process optional template parameters.
-            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
-            {
-                { "orderId", orderId },
-                { "itemId", itemId },
-            });
-
-            // append request with appropriate headers and parameters
-            var headers = new Dictionary<string, string>()
-            {
-                { "user-agent", this.UserAgent },
-                { "accept", "application/json" },
-                { "idempotency-key", idempotencyKey },
-            };
-
-            // prepare the API call request to fetch the response.
-            HttpRequest httpRequest = this.GetClientInstance().Delete(queryBuilder.ToString(), headers, null);
-
-            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
-
-            // invoke request and get response.
-            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
-            HttpContext context = new HttpContext(httpRequest, response);
-
-            // handle errors defined at the API level.
-            this.ValidateResponse(response, context);
-
-            return ApiHelper.JsonDeserialize<Models.GetOrderItemResponse>(response.Body);
-        }
-
-        /// <summary>
-        /// CloseOrder EndPoint.
-        /// </summary>
-        /// <param name="id">Required parameter: Order Id.</param>
-        /// <param name="request">Required parameter: Update Order Model.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <returns>Returns the Models.GetOrderResponse response from the API call.</returns>
-        public Models.GetOrderResponse CloseOrder(
-                string id,
-                Models.UpdateOrderStatusRequest request,
-                string idempotencyKey = null)
-        {
-            Task<Models.GetOrderResponse> t = this.CloseOrderAsync(id, request, idempotencyKey);
-            ApiHelper.RunTaskSynchronously(t);
-            return t.Result;
-        }
-
-        /// <summary>
-        /// CloseOrder EndPoint.
-        /// </summary>
-        /// <param name="id">Required parameter: Order Id.</param>
-        /// <param name="request">Required parameter: Update Order Model.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetOrderResponse response from the API call.</returns>
-        public async Task<Models.GetOrderResponse> CloseOrderAsync(
-                string id,
-                Models.UpdateOrderStatusRequest request,
-                string idempotencyKey = null,
-                CancellationToken cancellationToken = default)
-        {
-            // the base uri for api requests.
-            string baseUri = this.Config.GetBaseUri();
-
-            // prepare query string for API call.
-            StringBuilder queryBuilder = new StringBuilder(baseUri);
-            queryBuilder.Append("/orders/{id}/closed");
-
-            // process optional template parameters.
-            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
-            {
-                { "id", id },
-            });
-
-            // append request with appropriate headers and parameters
-            var headers = new Dictionary<string, string>()
-            {
-                { "user-agent", this.UserAgent },
-                { "accept", "application/json" },
-                { "content-type", "application/json; charset=utf-8" },
-                { "idempotency-key", idempotencyKey },
-            };
-
-            // append body params.
-            var bodyText = ApiHelper.JsonSerialize(request);
-
-            // prepare the API call request to fetch the response.
-            HttpRequest httpRequest = this.GetClientInstance().PatchBody(queryBuilder.ToString(), headers, bodyText);
-
-            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
-
-            // invoke request and get response.
-            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
-            HttpContext context = new HttpContext(httpRequest, response);
-
-            // handle errors defined at the API level.
-            this.ValidateResponse(response, context);
-
-            return ApiHelper.JsonDeserialize<Models.GetOrderResponse>(response.Body);
-        }
-
-        /// <summary>
-        /// Creates a new Order.
-        /// </summary>
-        /// <param name="body">Required parameter: Request for creating an order.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <returns>Returns the Models.GetOrderResponse response from the API call.</returns>
-        public Models.GetOrderResponse CreateOrder(
-                Models.CreateOrderRequest body,
-                string idempotencyKey = null)
-        {
-            Task<Models.GetOrderResponse> t = this.CreateOrderAsync(body, idempotencyKey);
-            ApiHelper.RunTaskSynchronously(t);
-            return t.Result;
-        }
-
-        /// <summary>
-        /// Creates a new Order.
-        /// </summary>
-        /// <param name="body">Required parameter: Request for creating an order.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetOrderResponse response from the API call.</returns>
-        public async Task<Models.GetOrderResponse> CreateOrderAsync(
-                Models.CreateOrderRequest body,
-                string idempotencyKey = null,
-                CancellationToken cancellationToken = default)
-        {
-            // the base uri for api requests.
-            string baseUri = this.Config.GetBaseUri();
-
-            // prepare query string for API call.
-            StringBuilder queryBuilder = new StringBuilder(baseUri);
-            queryBuilder.Append("/orders");
-
-            // append request with appropriate headers and parameters
-            var headers = new Dictionary<string, string>()
-            {
-                { "user-agent", this.UserAgent },
-                { "accept", "application/json" },
-                { "content-type", "application/json; charset=utf-8" },
-                { "idempotency-key", idempotencyKey },
-            };
-
-            // append body params.
-            var bodyText = ApiHelper.JsonSerialize(body);
-
-            // prepare the API call request to fetch the response.
-            HttpRequest httpRequest = this.GetClientInstance().PostBody(queryBuilder.ToString(), headers, bodyText);
-
-            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
-
-            // invoke request and get response.
-            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
-            HttpContext context = new HttpContext(httpRequest, response);
-
-            // handle errors defined at the API level.
-            this.ValidateResponse(response, context);
-
-            return ApiHelper.JsonDeserialize<Models.GetOrderResponse>(response.Body);
-        }
-
-        /// <summary>
-        /// CreateOrderItem EndPoint.
-        /// </summary>
-        /// <param name="orderId">Required parameter: Order Id.</param>
-        /// <param name="request">Required parameter: Order Item Model.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <returns>Returns the Models.GetOrderItemResponse response from the API call.</returns>
-        public Models.GetOrderItemResponse CreateOrderItem(
-                string orderId,
-                Models.CreateOrderItemRequest request,
-                string idempotencyKey = null)
-        {
-            Task<Models.GetOrderItemResponse> t = this.CreateOrderItemAsync(orderId, request, idempotencyKey);
-            ApiHelper.RunTaskSynchronously(t);
-            return t.Result;
-        }
-
-        /// <summary>
-        /// CreateOrderItem EndPoint.
-        /// </summary>
-        /// <param name="orderId">Required parameter: Order Id.</param>
-        /// <param name="request">Required parameter: Order Item Model.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetOrderItemResponse response from the API call.</returns>
-        public async Task<Models.GetOrderItemResponse> CreateOrderItemAsync(
-                string orderId,
-                Models.CreateOrderItemRequest request,
-                string idempotencyKey = null,
-                CancellationToken cancellationToken = default)
-        {
-            // the base uri for api requests.
-            string baseUri = this.Config.GetBaseUri();
-
-            // prepare query string for API call.
-            StringBuilder queryBuilder = new StringBuilder(baseUri);
-            queryBuilder.Append("/orders/{orderId}/items");
-
-            // process optional template parameters.
-            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
-            {
-                { "orderId", orderId },
-            });
-
-            // append request with appropriate headers and parameters
-            var headers = new Dictionary<string, string>()
-            {
-                { "user-agent", this.UserAgent },
-                { "accept", "application/json" },
-                { "content-type", "application/json; charset=utf-8" },
-                { "idempotency-key", idempotencyKey },
-            };
-
-            // append body params.
-            var bodyText = ApiHelper.JsonSerialize(request);
-
-            // prepare the API call request to fetch the response.
-            HttpRequest httpRequest = this.GetClientInstance().PostBody(queryBuilder.ToString(), headers, bodyText);
-
-            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
-
-            // invoke request and get response.
-            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
-            HttpContext context = new HttpContext(httpRequest, response);
-
-            // handle errors defined at the API level.
-            this.ValidateResponse(response, context);
-
-            return ApiHelper.JsonDeserialize<Models.GetOrderItemResponse>(response.Body);
-        }
-
-        /// <summary>
-        /// GetOrderItem EndPoint.
-        /// </summary>
-        /// <param name="orderId">Required parameter: Order Id.</param>
-        /// <param name="itemId">Required parameter: Item Id.</param>
-        /// <returns>Returns the Models.GetOrderItemResponse response from the API call.</returns>
-        public Models.GetOrderItemResponse GetOrderItem(
-                string orderId,
-                string itemId)
-        {
-            Task<Models.GetOrderItemResponse> t = this.GetOrderItemAsync(orderId, itemId);
-            ApiHelper.RunTaskSynchronously(t);
-            return t.Result;
-        }
-
-        /// <summary>
-        /// GetOrderItem EndPoint.
-        /// </summary>
-        /// <param name="orderId">Required parameter: Order Id.</param>
-        /// <param name="itemId">Required parameter: Item Id.</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetOrderItemResponse response from the API call.</returns>
-        public async Task<Models.GetOrderItemResponse> GetOrderItemAsync(
-                string orderId,
-                string itemId,
-                CancellationToken cancellationToken = default)
-        {
-            // the base uri for api requests.
-            string baseUri = this.Config.GetBaseUri();
-
-            // prepare query string for API call.
-            StringBuilder queryBuilder = new StringBuilder(baseUri);
-            queryBuilder.Append("/orders/{orderId}/items/{itemId}");
-
-            // process optional template parameters.
-            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
-            {
-                { "orderId", orderId },
-                { "itemId", itemId },
-            });
-
-            // append request with appropriate headers and parameters
-            var headers = new Dictionary<string, string>()
-            {
-                { "user-agent", this.UserAgent },
-                { "accept", "application/json" },
-            };
-
-            // prepare the API call request to fetch the response.
-            HttpRequest httpRequest = this.GetClientInstance().Get(queryBuilder.ToString(), headers);
-
-            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
-
-            // invoke request and get response.
-            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
-            HttpContext context = new HttpContext(httpRequest, response);
-
-            // handle errors defined at the API level.
-            this.ValidateResponse(response, context);
-
-            return ApiHelper.JsonDeserialize<Models.GetOrderItemResponse>(response.Body);
-        }
-
-        /// <summary>
         /// Updates the metadata from an order.
         /// </summary>
         /// <param name="orderId">Required parameter: The order id.</param>
@@ -669,26 +588,34 @@ namespace PagarmeApiSDK.Standard.Controllers
         }
 
         /// <summary>
-        /// Gets an order.
+        /// DeleteOrderItem EndPoint.
         /// </summary>
-        /// <param name="orderId">Required parameter: Order id.</param>
-        /// <returns>Returns the Models.GetOrderResponse response from the API call.</returns>
-        public Models.GetOrderResponse GetOrder(
-                string orderId)
+        /// <param name="orderId">Required parameter: Order Id.</param>
+        /// <param name="itemId">Required parameter: Item Id.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <returns>Returns the Models.GetOrderItemResponse response from the API call.</returns>
+        public Models.GetOrderItemResponse DeleteOrderItem(
+                string orderId,
+                string itemId,
+                string idempotencyKey = null)
         {
-            Task<Models.GetOrderResponse> t = this.GetOrderAsync(orderId);
+            Task<Models.GetOrderItemResponse> t = this.DeleteOrderItemAsync(orderId, itemId, idempotencyKey);
             ApiHelper.RunTaskSynchronously(t);
             return t.Result;
         }
 
         /// <summary>
-        /// Gets an order.
+        /// DeleteOrderItem EndPoint.
         /// </summary>
-        /// <param name="orderId">Required parameter: Order id.</param>
+        /// <param name="orderId">Required parameter: Order Id.</param>
+        /// <param name="itemId">Required parameter: Item Id.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
         /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetOrderResponse response from the API call.</returns>
-        public async Task<Models.GetOrderResponse> GetOrderAsync(
+        /// <returns>Returns the Models.GetOrderItemResponse response from the API call.</returns>
+        public async Task<Models.GetOrderItemResponse> DeleteOrderItemAsync(
                 string orderId,
+                string itemId,
+                string idempotencyKey = null,
                 CancellationToken cancellationToken = default)
         {
             // the base uri for api requests.
@@ -696,12 +623,13 @@ namespace PagarmeApiSDK.Standard.Controllers
 
             // prepare query string for API call.
             StringBuilder queryBuilder = new StringBuilder(baseUri);
-            queryBuilder.Append("/orders/{order_id}");
+            queryBuilder.Append("/orders/{orderId}/items/{itemId}");
 
             // process optional template parameters.
             ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
             {
-                { "order_id", orderId },
+                { "orderId", orderId },
+                { "itemId", itemId },
             });
 
             // append request with appropriate headers and parameters
@@ -709,10 +637,11 @@ namespace PagarmeApiSDK.Standard.Controllers
             {
                 { "user-agent", this.UserAgent },
                 { "accept", "application/json" },
+                { "idempotency-key", idempotencyKey },
             };
 
             // prepare the API call request to fetch the response.
-            HttpRequest httpRequest = this.GetClientInstance().Get(queryBuilder.ToString(), headers);
+            HttpRequest httpRequest = this.GetClientInstance().Delete(queryBuilder.ToString(), headers, null);
 
             httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
 
@@ -723,7 +652,78 @@ namespace PagarmeApiSDK.Standard.Controllers
             // handle errors defined at the API level.
             this.ValidateResponse(response, context);
 
-            return ApiHelper.JsonDeserialize<Models.GetOrderResponse>(response.Body);
+            return ApiHelper.JsonDeserialize<Models.GetOrderItemResponse>(response.Body);
+        }
+
+        /// <summary>
+        /// CreateOrderItem EndPoint.
+        /// </summary>
+        /// <param name="orderId">Required parameter: Order Id.</param>
+        /// <param name="request">Required parameter: Order Item Model.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <returns>Returns the Models.GetOrderItemResponse response from the API call.</returns>
+        public Models.GetOrderItemResponse CreateOrderItem(
+                string orderId,
+                Models.CreateOrderItemRequest request,
+                string idempotencyKey = null)
+        {
+            Task<Models.GetOrderItemResponse> t = this.CreateOrderItemAsync(orderId, request, idempotencyKey);
+            ApiHelper.RunTaskSynchronously(t);
+            return t.Result;
+        }
+
+        /// <summary>
+        /// CreateOrderItem EndPoint.
+        /// </summary>
+        /// <param name="orderId">Required parameter: Order Id.</param>
+        /// <param name="request">Required parameter: Order Item Model.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetOrderItemResponse response from the API call.</returns>
+        public async Task<Models.GetOrderItemResponse> CreateOrderItemAsync(
+                string orderId,
+                Models.CreateOrderItemRequest request,
+                string idempotencyKey = null,
+                CancellationToken cancellationToken = default)
+        {
+            // the base uri for api requests.
+            string baseUri = this.Config.GetBaseUri();
+
+            // prepare query string for API call.
+            StringBuilder queryBuilder = new StringBuilder(baseUri);
+            queryBuilder.Append("/orders/{orderId}/items");
+
+            // process optional template parameters.
+            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
+            {
+                { "orderId", orderId },
+            });
+
+            // append request with appropriate headers and parameters
+            var headers = new Dictionary<string, string>()
+            {
+                { "user-agent", this.UserAgent },
+                { "accept", "application/json" },
+                { "content-type", "application/json; charset=utf-8" },
+                { "idempotency-key", idempotencyKey },
+            };
+
+            // append body params.
+            var bodyText = ApiHelper.JsonSerialize(request);
+
+            // prepare the API call request to fetch the response.
+            HttpRequest httpRequest = this.GetClientInstance().PostBody(queryBuilder.ToString(), headers, bodyText);
+
+            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
+
+            // invoke request and get response.
+            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+            HttpContext context = new HttpContext(httpRequest, response);
+
+            // handle errors defined at the API level.
+            this.ValidateResponse(response, context);
+
+            return ApiHelper.JsonDeserialize<Models.GetOrderItemResponse>(response.Body);
         }
     }
 }

--- a/PagarmeApiSDK.Standard/Controllers/PlansController.cs
+++ b/PagarmeApiSDK.Standard/Controllers/PlansController.cs
@@ -95,29 +95,33 @@ namespace PagarmeApiSDK.Standard.Controllers
         }
 
         /// <summary>
-        /// Deletes a plan.
+        /// Updates a plan.
         /// </summary>
         /// <param name="planId">Required parameter: Plan id.</param>
+        /// <param name="request">Required parameter: Request for updating a plan.</param>
         /// <param name="idempotencyKey">Optional parameter: Example: .</param>
         /// <returns>Returns the Models.GetPlanResponse response from the API call.</returns>
-        public Models.GetPlanResponse DeletePlan(
+        public Models.GetPlanResponse UpdatePlan(
                 string planId,
+                Models.UpdatePlanRequest request,
                 string idempotencyKey = null)
         {
-            Task<Models.GetPlanResponse> t = this.DeletePlanAsync(planId, idempotencyKey);
+            Task<Models.GetPlanResponse> t = this.UpdatePlanAsync(planId, request, idempotencyKey);
             ApiHelper.RunTaskSynchronously(t);
             return t.Result;
         }
 
         /// <summary>
-        /// Deletes a plan.
+        /// Updates a plan.
         /// </summary>
         /// <param name="planId">Required parameter: Plan id.</param>
+        /// <param name="request">Required parameter: Request for updating a plan.</param>
         /// <param name="idempotencyKey">Optional parameter: Example: .</param>
         /// <param name="cancellationToken"> cancellationToken. </param>
         /// <returns>Returns the Models.GetPlanResponse response from the API call.</returns>
-        public async Task<Models.GetPlanResponse> DeletePlanAsync(
+        public async Task<Models.GetPlanResponse> UpdatePlanAsync(
                 string planId,
+                Models.UpdatePlanRequest request,
                 string idempotencyKey = null,
                 CancellationToken cancellationToken = default)
         {
@@ -139,11 +143,15 @@ namespace PagarmeApiSDK.Standard.Controllers
             {
                 { "user-agent", this.UserAgent },
                 { "accept", "application/json" },
+                { "content-type", "application/json; charset=utf-8" },
                 { "idempotency-key", idempotencyKey },
             };
 
+            // append body params.
+            var bodyText = ApiHelper.JsonSerialize(request);
+
             // prepare the API call request to fetch the response.
-            HttpRequest httpRequest = this.GetClientInstance().Delete(queryBuilder.ToString(), headers, null);
+            HttpRequest httpRequest = this.GetClientInstance().PutBody(queryBuilder.ToString(), headers, bodyText);
 
             httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
 
@@ -215,277 +223,6 @@ namespace PagarmeApiSDK.Standard.Controllers
 
             // prepare the API call request to fetch the response.
             HttpRequest httpRequest = this.GetClientInstance().PatchBody(queryBuilder.ToString(), headers, bodyText);
-
-            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
-
-            // invoke request and get response.
-            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
-            HttpContext context = new HttpContext(httpRequest, response);
-
-            // handle errors defined at the API level.
-            this.ValidateResponse(response, context);
-
-            return ApiHelper.JsonDeserialize<Models.GetPlanResponse>(response.Body);
-        }
-
-        /// <summary>
-        /// Updates a plan item.
-        /// </summary>
-        /// <param name="planId">Required parameter: Plan id.</param>
-        /// <param name="planItemId">Required parameter: Plan item id.</param>
-        /// <param name="body">Required parameter: Request for updating the plan item.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <returns>Returns the Models.GetPlanItemResponse response from the API call.</returns>
-        public Models.GetPlanItemResponse UpdatePlanItem(
-                string planId,
-                string planItemId,
-                Models.UpdatePlanItemRequest body,
-                string idempotencyKey = null)
-        {
-            Task<Models.GetPlanItemResponse> t = this.UpdatePlanItemAsync(planId, planItemId, body, idempotencyKey);
-            ApiHelper.RunTaskSynchronously(t);
-            return t.Result;
-        }
-
-        /// <summary>
-        /// Updates a plan item.
-        /// </summary>
-        /// <param name="planId">Required parameter: Plan id.</param>
-        /// <param name="planItemId">Required parameter: Plan item id.</param>
-        /// <param name="body">Required parameter: Request for updating the plan item.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetPlanItemResponse response from the API call.</returns>
-        public async Task<Models.GetPlanItemResponse> UpdatePlanItemAsync(
-                string planId,
-                string planItemId,
-                Models.UpdatePlanItemRequest body,
-                string idempotencyKey = null,
-                CancellationToken cancellationToken = default)
-        {
-            // the base uri for api requests.
-            string baseUri = this.Config.GetBaseUri();
-
-            // prepare query string for API call.
-            StringBuilder queryBuilder = new StringBuilder(baseUri);
-            queryBuilder.Append("/plans/{plan_id}/items/{plan_item_id}");
-
-            // process optional template parameters.
-            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
-            {
-                { "plan_id", planId },
-                { "plan_item_id", planItemId },
-            });
-
-            // append request with appropriate headers and parameters
-            var headers = new Dictionary<string, string>()
-            {
-                { "user-agent", this.UserAgent },
-                { "accept", "application/json" },
-                { "content-type", "application/json; charset=utf-8" },
-                { "idempotency-key", idempotencyKey },
-            };
-
-            // append body params.
-            var bodyText = ApiHelper.JsonSerialize(body);
-
-            // prepare the API call request to fetch the response.
-            HttpRequest httpRequest = this.GetClientInstance().PutBody(queryBuilder.ToString(), headers, bodyText);
-
-            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
-
-            // invoke request and get response.
-            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
-            HttpContext context = new HttpContext(httpRequest, response);
-
-            // handle errors defined at the API level.
-            this.ValidateResponse(response, context);
-
-            return ApiHelper.JsonDeserialize<Models.GetPlanItemResponse>(response.Body);
-        }
-
-        /// <summary>
-        /// Adds a new item to a plan.
-        /// </summary>
-        /// <param name="planId">Required parameter: Plan id.</param>
-        /// <param name="request">Required parameter: Request for creating a plan item.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <returns>Returns the Models.GetPlanItemResponse response from the API call.</returns>
-        public Models.GetPlanItemResponse CreatePlanItem(
-                string planId,
-                Models.CreatePlanItemRequest request,
-                string idempotencyKey = null)
-        {
-            Task<Models.GetPlanItemResponse> t = this.CreatePlanItemAsync(planId, request, idempotencyKey);
-            ApiHelper.RunTaskSynchronously(t);
-            return t.Result;
-        }
-
-        /// <summary>
-        /// Adds a new item to a plan.
-        /// </summary>
-        /// <param name="planId">Required parameter: Plan id.</param>
-        /// <param name="request">Required parameter: Request for creating a plan item.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetPlanItemResponse response from the API call.</returns>
-        public async Task<Models.GetPlanItemResponse> CreatePlanItemAsync(
-                string planId,
-                Models.CreatePlanItemRequest request,
-                string idempotencyKey = null,
-                CancellationToken cancellationToken = default)
-        {
-            // the base uri for api requests.
-            string baseUri = this.Config.GetBaseUri();
-
-            // prepare query string for API call.
-            StringBuilder queryBuilder = new StringBuilder(baseUri);
-            queryBuilder.Append("/plans/{plan_id}/items");
-
-            // process optional template parameters.
-            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
-            {
-                { "plan_id", planId },
-            });
-
-            // append request with appropriate headers and parameters
-            var headers = new Dictionary<string, string>()
-            {
-                { "user-agent", this.UserAgent },
-                { "accept", "application/json" },
-                { "content-type", "application/json; charset=utf-8" },
-                { "idempotency-key", idempotencyKey },
-            };
-
-            // append body params.
-            var bodyText = ApiHelper.JsonSerialize(request);
-
-            // prepare the API call request to fetch the response.
-            HttpRequest httpRequest = this.GetClientInstance().PostBody(queryBuilder.ToString(), headers, bodyText);
-
-            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
-
-            // invoke request and get response.
-            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
-            HttpContext context = new HttpContext(httpRequest, response);
-
-            // handle errors defined at the API level.
-            this.ValidateResponse(response, context);
-
-            return ApiHelper.JsonDeserialize<Models.GetPlanItemResponse>(response.Body);
-        }
-
-        /// <summary>
-        /// Gets a plan item.
-        /// </summary>
-        /// <param name="planId">Required parameter: Plan id.</param>
-        /// <param name="planItemId">Required parameter: Plan item id.</param>
-        /// <returns>Returns the Models.GetPlanItemResponse response from the API call.</returns>
-        public Models.GetPlanItemResponse GetPlanItem(
-                string planId,
-                string planItemId)
-        {
-            Task<Models.GetPlanItemResponse> t = this.GetPlanItemAsync(planId, planItemId);
-            ApiHelper.RunTaskSynchronously(t);
-            return t.Result;
-        }
-
-        /// <summary>
-        /// Gets a plan item.
-        /// </summary>
-        /// <param name="planId">Required parameter: Plan id.</param>
-        /// <param name="planItemId">Required parameter: Plan item id.</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetPlanItemResponse response from the API call.</returns>
-        public async Task<Models.GetPlanItemResponse> GetPlanItemAsync(
-                string planId,
-                string planItemId,
-                CancellationToken cancellationToken = default)
-        {
-            // the base uri for api requests.
-            string baseUri = this.Config.GetBaseUri();
-
-            // prepare query string for API call.
-            StringBuilder queryBuilder = new StringBuilder(baseUri);
-            queryBuilder.Append("/plans/{plan_id}/items/{plan_item_id}");
-
-            // process optional template parameters.
-            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
-            {
-                { "plan_id", planId },
-                { "plan_item_id", planItemId },
-            });
-
-            // append request with appropriate headers and parameters
-            var headers = new Dictionary<string, string>()
-            {
-                { "user-agent", this.UserAgent },
-                { "accept", "application/json" },
-            };
-
-            // prepare the API call request to fetch the response.
-            HttpRequest httpRequest = this.GetClientInstance().Get(queryBuilder.ToString(), headers);
-
-            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
-
-            // invoke request and get response.
-            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
-            HttpContext context = new HttpContext(httpRequest, response);
-
-            // handle errors defined at the API level.
-            this.ValidateResponse(response, context);
-
-            return ApiHelper.JsonDeserialize<Models.GetPlanItemResponse>(response.Body);
-        }
-
-        /// <summary>
-        /// Creates a new plan.
-        /// </summary>
-        /// <param name="body">Required parameter: Request for creating a plan.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <returns>Returns the Models.GetPlanResponse response from the API call.</returns>
-        public Models.GetPlanResponse CreatePlan(
-                Models.CreatePlanRequest body,
-                string idempotencyKey = null)
-        {
-            Task<Models.GetPlanResponse> t = this.CreatePlanAsync(body, idempotencyKey);
-            ApiHelper.RunTaskSynchronously(t);
-            return t.Result;
-        }
-
-        /// <summary>
-        /// Creates a new plan.
-        /// </summary>
-        /// <param name="body">Required parameter: Request for creating a plan.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetPlanResponse response from the API call.</returns>
-        public async Task<Models.GetPlanResponse> CreatePlanAsync(
-                Models.CreatePlanRequest body,
-                string idempotencyKey = null,
-                CancellationToken cancellationToken = default)
-        {
-            // the base uri for api requests.
-            string baseUri = this.Config.GetBaseUri();
-
-            // prepare query string for API call.
-            StringBuilder queryBuilder = new StringBuilder(baseUri);
-            queryBuilder.Append("/plans");
-
-            // append request with appropriate headers and parameters
-            var headers = new Dictionary<string, string>()
-            {
-                { "user-agent", this.UserAgent },
-                { "accept", "application/json" },
-                { "content-type", "application/json; charset=utf-8" },
-                { "idempotency-key", idempotencyKey },
-            };
-
-            // append body params.
-            var bodyText = ApiHelper.JsonSerialize(body);
-
-            // prepare the API call request to fetch the response.
-            HttpRequest httpRequest = this.GetClientInstance().PostBody(queryBuilder.ToString(), headers, bodyText);
 
             httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
 
@@ -656,33 +393,92 @@ namespace PagarmeApiSDK.Standard.Controllers
         }
 
         /// <summary>
-        /// Updates a plan.
+        /// Gets a plan item.
         /// </summary>
         /// <param name="planId">Required parameter: Plan id.</param>
-        /// <param name="request">Required parameter: Request for updating a plan.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <returns>Returns the Models.GetPlanResponse response from the API call.</returns>
-        public Models.GetPlanResponse UpdatePlan(
+        /// <param name="planItemId">Required parameter: Plan item id.</param>
+        /// <returns>Returns the Models.GetPlanItemResponse response from the API call.</returns>
+        public Models.GetPlanItemResponse GetPlanItem(
                 string planId,
-                Models.UpdatePlanRequest request,
-                string idempotencyKey = null)
+                string planItemId)
         {
-            Task<Models.GetPlanResponse> t = this.UpdatePlanAsync(planId, request, idempotencyKey);
+            Task<Models.GetPlanItemResponse> t = this.GetPlanItemAsync(planId, planItemId);
             ApiHelper.RunTaskSynchronously(t);
             return t.Result;
         }
 
         /// <summary>
-        /// Updates a plan.
+        /// Gets a plan item.
         /// </summary>
         /// <param name="planId">Required parameter: Plan id.</param>
-        /// <param name="request">Required parameter: Request for updating a plan.</param>
+        /// <param name="planItemId">Required parameter: Plan item id.</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetPlanItemResponse response from the API call.</returns>
+        public async Task<Models.GetPlanItemResponse> GetPlanItemAsync(
+                string planId,
+                string planItemId,
+                CancellationToken cancellationToken = default)
+        {
+            // the base uri for api requests.
+            string baseUri = this.Config.GetBaseUri();
+
+            // prepare query string for API call.
+            StringBuilder queryBuilder = new StringBuilder(baseUri);
+            queryBuilder.Append("/plans/{plan_id}/items/{plan_item_id}");
+
+            // process optional template parameters.
+            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
+            {
+                { "plan_id", planId },
+                { "plan_item_id", planItemId },
+            });
+
+            // append request with appropriate headers and parameters
+            var headers = new Dictionary<string, string>()
+            {
+                { "user-agent", this.UserAgent },
+                { "accept", "application/json" },
+            };
+
+            // prepare the API call request to fetch the response.
+            HttpRequest httpRequest = this.GetClientInstance().Get(queryBuilder.ToString(), headers);
+
+            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
+
+            // invoke request and get response.
+            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+            HttpContext context = new HttpContext(httpRequest, response);
+
+            // handle errors defined at the API level.
+            this.ValidateResponse(response, context);
+
+            return ApiHelper.JsonDeserialize<Models.GetPlanItemResponse>(response.Body);
+        }
+
+        /// <summary>
+        /// Deletes a plan.
+        /// </summary>
+        /// <param name="planId">Required parameter: Plan id.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <returns>Returns the Models.GetPlanResponse response from the API call.</returns>
+        public Models.GetPlanResponse DeletePlan(
+                string planId,
+                string idempotencyKey = null)
+        {
+            Task<Models.GetPlanResponse> t = this.DeletePlanAsync(planId, idempotencyKey);
+            ApiHelper.RunTaskSynchronously(t);
+            return t.Result;
+        }
+
+        /// <summary>
+        /// Deletes a plan.
+        /// </summary>
+        /// <param name="planId">Required parameter: Plan id.</param>
         /// <param name="idempotencyKey">Optional parameter: Example: .</param>
         /// <param name="cancellationToken"> cancellationToken. </param>
         /// <returns>Returns the Models.GetPlanResponse response from the API call.</returns>
-        public async Task<Models.GetPlanResponse> UpdatePlanAsync(
+        public async Task<Models.GetPlanResponse> DeletePlanAsync(
                 string planId,
-                Models.UpdatePlanRequest request,
                 string idempotencyKey = null,
                 CancellationToken cancellationToken = default)
         {
@@ -704,6 +500,149 @@ namespace PagarmeApiSDK.Standard.Controllers
             {
                 { "user-agent", this.UserAgent },
                 { "accept", "application/json" },
+                { "idempotency-key", idempotencyKey },
+            };
+
+            // prepare the API call request to fetch the response.
+            HttpRequest httpRequest = this.GetClientInstance().Delete(queryBuilder.ToString(), headers, null);
+
+            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
+
+            // invoke request and get response.
+            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+            HttpContext context = new HttpContext(httpRequest, response);
+
+            // handle errors defined at the API level.
+            this.ValidateResponse(response, context);
+
+            return ApiHelper.JsonDeserialize<Models.GetPlanResponse>(response.Body);
+        }
+
+        /// <summary>
+        /// Updates a plan item.
+        /// </summary>
+        /// <param name="planId">Required parameter: Plan id.</param>
+        /// <param name="planItemId">Required parameter: Plan item id.</param>
+        /// <param name="body">Required parameter: Request for updating the plan item.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <returns>Returns the Models.GetPlanItemResponse response from the API call.</returns>
+        public Models.GetPlanItemResponse UpdatePlanItem(
+                string planId,
+                string planItemId,
+                Models.UpdatePlanItemRequest body,
+                string idempotencyKey = null)
+        {
+            Task<Models.GetPlanItemResponse> t = this.UpdatePlanItemAsync(planId, planItemId, body, idempotencyKey);
+            ApiHelper.RunTaskSynchronously(t);
+            return t.Result;
+        }
+
+        /// <summary>
+        /// Updates a plan item.
+        /// </summary>
+        /// <param name="planId">Required parameter: Plan id.</param>
+        /// <param name="planItemId">Required parameter: Plan item id.</param>
+        /// <param name="body">Required parameter: Request for updating the plan item.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetPlanItemResponse response from the API call.</returns>
+        public async Task<Models.GetPlanItemResponse> UpdatePlanItemAsync(
+                string planId,
+                string planItemId,
+                Models.UpdatePlanItemRequest body,
+                string idempotencyKey = null,
+                CancellationToken cancellationToken = default)
+        {
+            // the base uri for api requests.
+            string baseUri = this.Config.GetBaseUri();
+
+            // prepare query string for API call.
+            StringBuilder queryBuilder = new StringBuilder(baseUri);
+            queryBuilder.Append("/plans/{plan_id}/items/{plan_item_id}");
+
+            // process optional template parameters.
+            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
+            {
+                { "plan_id", planId },
+                { "plan_item_id", planItemId },
+            });
+
+            // append request with appropriate headers and parameters
+            var headers = new Dictionary<string, string>()
+            {
+                { "user-agent", this.UserAgent },
+                { "accept", "application/json" },
+                { "content-type", "application/json; charset=utf-8" },
+                { "idempotency-key", idempotencyKey },
+            };
+
+            // append body params.
+            var bodyText = ApiHelper.JsonSerialize(body);
+
+            // prepare the API call request to fetch the response.
+            HttpRequest httpRequest = this.GetClientInstance().PutBody(queryBuilder.ToString(), headers, bodyText);
+
+            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
+
+            // invoke request and get response.
+            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+            HttpContext context = new HttpContext(httpRequest, response);
+
+            // handle errors defined at the API level.
+            this.ValidateResponse(response, context);
+
+            return ApiHelper.JsonDeserialize<Models.GetPlanItemResponse>(response.Body);
+        }
+
+        /// <summary>
+        /// Adds a new item to a plan.
+        /// </summary>
+        /// <param name="planId">Required parameter: Plan id.</param>
+        /// <param name="request">Required parameter: Request for creating a plan item.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <returns>Returns the Models.GetPlanItemResponse response from the API call.</returns>
+        public Models.GetPlanItemResponse CreatePlanItem(
+                string planId,
+                Models.CreatePlanItemRequest request,
+                string idempotencyKey = null)
+        {
+            Task<Models.GetPlanItemResponse> t = this.CreatePlanItemAsync(planId, request, idempotencyKey);
+            ApiHelper.RunTaskSynchronously(t);
+            return t.Result;
+        }
+
+        /// <summary>
+        /// Adds a new item to a plan.
+        /// </summary>
+        /// <param name="planId">Required parameter: Plan id.</param>
+        /// <param name="request">Required parameter: Request for creating a plan item.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetPlanItemResponse response from the API call.</returns>
+        public async Task<Models.GetPlanItemResponse> CreatePlanItemAsync(
+                string planId,
+                Models.CreatePlanItemRequest request,
+                string idempotencyKey = null,
+                CancellationToken cancellationToken = default)
+        {
+            // the base uri for api requests.
+            string baseUri = this.Config.GetBaseUri();
+
+            // prepare query string for API call.
+            StringBuilder queryBuilder = new StringBuilder(baseUri);
+            queryBuilder.Append("/plans/{plan_id}/items");
+
+            // process optional template parameters.
+            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
+            {
+                { "plan_id", planId },
+            });
+
+            // append request with appropriate headers and parameters
+            var headers = new Dictionary<string, string>()
+            {
+                { "user-agent", this.UserAgent },
+                { "accept", "application/json" },
                 { "content-type", "application/json; charset=utf-8" },
                 { "idempotency-key", idempotencyKey },
             };
@@ -712,7 +651,68 @@ namespace PagarmeApiSDK.Standard.Controllers
             var bodyText = ApiHelper.JsonSerialize(request);
 
             // prepare the API call request to fetch the response.
-            HttpRequest httpRequest = this.GetClientInstance().PutBody(queryBuilder.ToString(), headers, bodyText);
+            HttpRequest httpRequest = this.GetClientInstance().PostBody(queryBuilder.ToString(), headers, bodyText);
+
+            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
+
+            // invoke request and get response.
+            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+            HttpContext context = new HttpContext(httpRequest, response);
+
+            // handle errors defined at the API level.
+            this.ValidateResponse(response, context);
+
+            return ApiHelper.JsonDeserialize<Models.GetPlanItemResponse>(response.Body);
+        }
+
+        /// <summary>
+        /// Creates a new plan.
+        /// </summary>
+        /// <param name="body">Required parameter: Request for creating a plan.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <returns>Returns the Models.GetPlanResponse response from the API call.</returns>
+        public Models.GetPlanResponse CreatePlan(
+                Models.CreatePlanRequest body,
+                string idempotencyKey = null)
+        {
+            Task<Models.GetPlanResponse> t = this.CreatePlanAsync(body, idempotencyKey);
+            ApiHelper.RunTaskSynchronously(t);
+            return t.Result;
+        }
+
+        /// <summary>
+        /// Creates a new plan.
+        /// </summary>
+        /// <param name="body">Required parameter: Request for creating a plan.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetPlanResponse response from the API call.</returns>
+        public async Task<Models.GetPlanResponse> CreatePlanAsync(
+                Models.CreatePlanRequest body,
+                string idempotencyKey = null,
+                CancellationToken cancellationToken = default)
+        {
+            // the base uri for api requests.
+            string baseUri = this.Config.GetBaseUri();
+
+            // prepare query string for API call.
+            StringBuilder queryBuilder = new StringBuilder(baseUri);
+            queryBuilder.Append("/plans");
+
+            // append request with appropriate headers and parameters
+            var headers = new Dictionary<string, string>()
+            {
+                { "user-agent", this.UserAgent },
+                { "accept", "application/json" },
+                { "content-type", "application/json; charset=utf-8" },
+                { "idempotency-key", idempotencyKey },
+            };
+
+            // append body params.
+            var bodyText = ApiHelper.JsonSerialize(body);
+
+            // prepare the API call request to fetch the response.
+            HttpRequest httpRequest = this.GetClientInstance().PostBody(queryBuilder.ToString(), headers, bodyText);
 
             httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
 

--- a/PagarmeApiSDK.Standard/Controllers/RecipientsController.cs
+++ b/PagarmeApiSDK.Standard/Controllers/RecipientsController.cs
@@ -315,140 +315,6 @@ namespace PagarmeApiSDK.Standard.Controllers
         }
 
         /// <summary>
-        /// GetWithdrawById EndPoint.
-        /// </summary>
-        /// <param name="recipientId">Required parameter: Example: .</param>
-        /// <param name="withdrawalId">Required parameter: Example: .</param>
-        /// <returns>Returns the Models.GetWithdrawResponse response from the API call.</returns>
-        public Models.GetWithdrawResponse GetWithdrawById(
-                string recipientId,
-                string withdrawalId)
-        {
-            Task<Models.GetWithdrawResponse> t = this.GetWithdrawByIdAsync(recipientId, withdrawalId);
-            ApiHelper.RunTaskSynchronously(t);
-            return t.Result;
-        }
-
-        /// <summary>
-        /// GetWithdrawById EndPoint.
-        /// </summary>
-        /// <param name="recipientId">Required parameter: Example: .</param>
-        /// <param name="withdrawalId">Required parameter: Example: .</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetWithdrawResponse response from the API call.</returns>
-        public async Task<Models.GetWithdrawResponse> GetWithdrawByIdAsync(
-                string recipientId,
-                string withdrawalId,
-                CancellationToken cancellationToken = default)
-        {
-            // the base uri for api requests.
-            string baseUri = this.Config.GetBaseUri();
-
-            // prepare query string for API call.
-            StringBuilder queryBuilder = new StringBuilder(baseUri);
-            queryBuilder.Append("/recipients/{recipient_id}/withdrawals/{withdrawal_id}");
-
-            // process optional template parameters.
-            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
-            {
-                { "recipient_id", recipientId },
-                { "withdrawal_id", withdrawalId },
-            });
-
-            // append request with appropriate headers and parameters
-            var headers = new Dictionary<string, string>()
-            {
-                { "user-agent", this.UserAgent },
-                { "accept", "application/json" },
-            };
-
-            // prepare the API call request to fetch the response.
-            HttpRequest httpRequest = this.GetClientInstance().Get(queryBuilder.ToString(), headers);
-
-            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
-
-            // invoke request and get response.
-            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
-            HttpContext context = new HttpContext(httpRequest, response);
-
-            // handle errors defined at the API level.
-            this.ValidateResponse(response, context);
-
-            return ApiHelper.JsonDeserialize<Models.GetWithdrawResponse>(response.Body);
-        }
-
-        /// <summary>
-        /// Updates the default bank account from a recipient.
-        /// </summary>
-        /// <param name="recipientId">Required parameter: Recipient id.</param>
-        /// <param name="request">Required parameter: Bank account data.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <returns>Returns the Models.GetRecipientResponse response from the API call.</returns>
-        public Models.GetRecipientResponse UpdateRecipientDefaultBankAccount(
-                string recipientId,
-                Models.UpdateRecipientBankAccountRequest request,
-                string idempotencyKey = null)
-        {
-            Task<Models.GetRecipientResponse> t = this.UpdateRecipientDefaultBankAccountAsync(recipientId, request, idempotencyKey);
-            ApiHelper.RunTaskSynchronously(t);
-            return t.Result;
-        }
-
-        /// <summary>
-        /// Updates the default bank account from a recipient.
-        /// </summary>
-        /// <param name="recipientId">Required parameter: Recipient id.</param>
-        /// <param name="request">Required parameter: Bank account data.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetRecipientResponse response from the API call.</returns>
-        public async Task<Models.GetRecipientResponse> UpdateRecipientDefaultBankAccountAsync(
-                string recipientId,
-                Models.UpdateRecipientBankAccountRequest request,
-                string idempotencyKey = null,
-                CancellationToken cancellationToken = default)
-        {
-            // the base uri for api requests.
-            string baseUri = this.Config.GetBaseUri();
-
-            // prepare query string for API call.
-            StringBuilder queryBuilder = new StringBuilder(baseUri);
-            queryBuilder.Append("/recipients/{recipient_id}/default-bank-account");
-
-            // process optional template parameters.
-            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
-            {
-                { "recipient_id", recipientId },
-            });
-
-            // append request with appropriate headers and parameters
-            var headers = new Dictionary<string, string>()
-            {
-                { "user-agent", this.UserAgent },
-                { "accept", "application/json" },
-                { "content-type", "application/json; charset=utf-8" },
-                { "idempotency-key", idempotencyKey },
-            };
-
-            // append body params.
-            var bodyText = ApiHelper.JsonSerialize(request);
-
-            // prepare the API call request to fetch the response.
-            HttpRequest httpRequest = this.GetClientInstance().PatchBody(queryBuilder.ToString(), headers, bodyText);
-
-            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
-
-            // invoke request and get response.
-            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
-            HttpContext context = new HttpContext(httpRequest, response);
-
-            // handle errors defined at the API level.
-            this.ValidateResponse(response, context);
-
-            return ApiHelper.JsonDeserialize<Models.GetRecipientResponse>(response.Body);
-        }
-
-        /// <summary>
         /// Updates recipient metadata.
         /// </summary>
         /// <param name="recipientId">Required parameter: Recipient id.</param>
@@ -520,94 +386,6 @@ namespace PagarmeApiSDK.Standard.Controllers
         }
 
         /// <summary>
-        /// Gets a paginated list of transfers for the recipient.
-        /// </summary>
-        /// <param name="recipientId">Required parameter: Recipient id.</param>
-        /// <param name="page">Optional parameter: Page number.</param>
-        /// <param name="size">Optional parameter: Page size.</param>
-        /// <param name="status">Optional parameter: Filter for transfer status.</param>
-        /// <param name="createdSince">Optional parameter: Filter for start range of transfer creation date.</param>
-        /// <param name="createdUntil">Optional parameter: Filter for end range of transfer creation date.</param>
-        /// <returns>Returns the Models.ListTransferResponse response from the API call.</returns>
-        public Models.ListTransferResponse GetTransfers(
-                string recipientId,
-                int? page = null,
-                int? size = null,
-                string status = null,
-                DateTime? createdSince = null,
-                DateTime? createdUntil = null)
-        {
-            Task<Models.ListTransferResponse> t = this.GetTransfersAsync(recipientId, page, size, status, createdSince, createdUntil);
-            ApiHelper.RunTaskSynchronously(t);
-            return t.Result;
-        }
-
-        /// <summary>
-        /// Gets a paginated list of transfers for the recipient.
-        /// </summary>
-        /// <param name="recipientId">Required parameter: Recipient id.</param>
-        /// <param name="page">Optional parameter: Page number.</param>
-        /// <param name="size">Optional parameter: Page size.</param>
-        /// <param name="status">Optional parameter: Filter for transfer status.</param>
-        /// <param name="createdSince">Optional parameter: Filter for start range of transfer creation date.</param>
-        /// <param name="createdUntil">Optional parameter: Filter for end range of transfer creation date.</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.ListTransferResponse response from the API call.</returns>
-        public async Task<Models.ListTransferResponse> GetTransfersAsync(
-                string recipientId,
-                int? page = null,
-                int? size = null,
-                string status = null,
-                DateTime? createdSince = null,
-                DateTime? createdUntil = null,
-                CancellationToken cancellationToken = default)
-        {
-            // the base uri for api requests.
-            string baseUri = this.Config.GetBaseUri();
-
-            // prepare query string for API call.
-            StringBuilder queryBuilder = new StringBuilder(baseUri);
-            queryBuilder.Append("/recipients/{recipient_id}/transfers");
-
-            // process optional template parameters.
-            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
-            {
-                { "recipient_id", recipientId },
-            });
-
-            // prepare specfied query parameters.
-            var queryParams = new Dictionary<string, object>()
-            {
-                { "page", page },
-                { "size", size },
-                { "status", status },
-                { "created_since", createdSince.HasValue ? createdSince.Value.ToString("yyyy'-'MM'-'dd'T'HH':'mm':'ss.FFFFFFFK") : null },
-                { "created_until", createdUntil.HasValue ? createdUntil.Value.ToString("yyyy'-'MM'-'dd'T'HH':'mm':'ss.FFFFFFFK") : null },
-            };
-
-            // append request with appropriate headers and parameters
-            var headers = new Dictionary<string, string>()
-            {
-                { "user-agent", this.UserAgent },
-                { "accept", "application/json" },
-            };
-
-            // prepare the API call request to fetch the response.
-            HttpRequest httpRequest = this.GetClientInstance().Get(queryBuilder.ToString(), headers, queryParameters: queryParams);
-
-            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
-
-            // invoke request and get response.
-            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
-            HttpContext context = new HttpContext(httpRequest, response);
-
-            // handle errors defined at the API level.
-            this.ValidateResponse(response, context);
-
-            return ApiHelper.JsonDeserialize<Models.ListTransferResponse>(response.Body);
-        }
-
-        /// <summary>
         /// Gets a transfer.
         /// </summary>
         /// <param name="recipientId">Required parameter: Recipient id.</param>
@@ -668,143 +446,6 @@ namespace PagarmeApiSDK.Standard.Controllers
             this.ValidateResponse(response, context);
 
             return ApiHelper.JsonDeserialize<Models.GetTransferResponse>(response.Body);
-        }
-
-        /// <summary>
-        /// CreateWithdraw EndPoint.
-        /// </summary>
-        /// <param name="recipientId">Required parameter: Example: .</param>
-        /// <param name="request">Required parameter: Example: .</param>
-        /// <returns>Returns the Models.GetWithdrawResponse response from the API call.</returns>
-        public Models.GetWithdrawResponse CreateWithdraw(
-                string recipientId,
-                Models.CreateWithdrawRequest request)
-        {
-            Task<Models.GetWithdrawResponse> t = this.CreateWithdrawAsync(recipientId, request);
-            ApiHelper.RunTaskSynchronously(t);
-            return t.Result;
-        }
-
-        /// <summary>
-        /// CreateWithdraw EndPoint.
-        /// </summary>
-        /// <param name="recipientId">Required parameter: Example: .</param>
-        /// <param name="request">Required parameter: Example: .</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetWithdrawResponse response from the API call.</returns>
-        public async Task<Models.GetWithdrawResponse> CreateWithdrawAsync(
-                string recipientId,
-                Models.CreateWithdrawRequest request,
-                CancellationToken cancellationToken = default)
-        {
-            // the base uri for api requests.
-            string baseUri = this.Config.GetBaseUri();
-
-            // prepare query string for API call.
-            StringBuilder queryBuilder = new StringBuilder(baseUri);
-            queryBuilder.Append("/recipients/{recipient_id}/withdrawals");
-
-            // process optional template parameters.
-            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
-            {
-                { "recipient_id", recipientId },
-            });
-
-            // append request with appropriate headers and parameters
-            var headers = new Dictionary<string, string>()
-            {
-                { "user-agent", this.UserAgent },
-                { "accept", "application/json" },
-                { "content-type", "application/json; charset=utf-8" },
-            };
-
-            // append body params.
-            var bodyText = ApiHelper.JsonSerialize(request);
-
-            // prepare the API call request to fetch the response.
-            HttpRequest httpRequest = this.GetClientInstance().PostBody(queryBuilder.ToString(), headers, bodyText);
-
-            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
-
-            // invoke request and get response.
-            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
-            HttpContext context = new HttpContext(httpRequest, response);
-
-            // handle errors defined at the API level.
-            this.ValidateResponse(response, context);
-
-            return ApiHelper.JsonDeserialize<Models.GetWithdrawResponse>(response.Body);
-        }
-
-        /// <summary>
-        /// Updates recipient metadata.
-        /// </summary>
-        /// <param name="recipientId">Required parameter: Recipient id.</param>
-        /// <param name="request">Required parameter: Metadata.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <returns>Returns the Models.GetRecipientResponse response from the API call.</returns>
-        public Models.GetRecipientResponse UpdateAutomaticAnticipationSettings(
-                string recipientId,
-                Models.UpdateAutomaticAnticipationSettingsRequest request,
-                string idempotencyKey = null)
-        {
-            Task<Models.GetRecipientResponse> t = this.UpdateAutomaticAnticipationSettingsAsync(recipientId, request, idempotencyKey);
-            ApiHelper.RunTaskSynchronously(t);
-            return t.Result;
-        }
-
-        /// <summary>
-        /// Updates recipient metadata.
-        /// </summary>
-        /// <param name="recipientId">Required parameter: Recipient id.</param>
-        /// <param name="request">Required parameter: Metadata.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetRecipientResponse response from the API call.</returns>
-        public async Task<Models.GetRecipientResponse> UpdateAutomaticAnticipationSettingsAsync(
-                string recipientId,
-                Models.UpdateAutomaticAnticipationSettingsRequest request,
-                string idempotencyKey = null,
-                CancellationToken cancellationToken = default)
-        {
-            // the base uri for api requests.
-            string baseUri = this.Config.GetBaseUri();
-
-            // prepare query string for API call.
-            StringBuilder queryBuilder = new StringBuilder(baseUri);
-            queryBuilder.Append("/recipients/{recipient_id}/automatic-anticipation-settings");
-
-            // process optional template parameters.
-            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
-            {
-                { "recipient_id", recipientId },
-            });
-
-            // append request with appropriate headers and parameters
-            var headers = new Dictionary<string, string>()
-            {
-                { "user-agent", this.UserAgent },
-                { "accept", "application/json" },
-                { "content-type", "application/json; charset=utf-8" },
-                { "idempotency-key", idempotencyKey },
-            };
-
-            // append body params.
-            var bodyText = ApiHelper.JsonSerialize(request);
-
-            // prepare the API call request to fetch the response.
-            HttpRequest httpRequest = this.GetClientInstance().PatchBody(queryBuilder.ToString(), headers, bodyText);
-
-            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
-
-            // invoke request and get response.
-            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
-            HttpContext context = new HttpContext(httpRequest, response);
-
-            // handle errors defined at the API level.
-            this.ValidateResponse(response, context);
-
-            return ApiHelper.JsonDeserialize<Models.GetRecipientResponse>(response.Body);
         }
 
         /// <summary>
@@ -1045,26 +686,34 @@ namespace PagarmeApiSDK.Standard.Controllers
         }
 
         /// <summary>
-        /// Retrieves recipient information.
+        /// Updates the default bank account from a recipient.
         /// </summary>
-        /// <param name="recipientId">Required parameter: Recipiend id.</param>
+        /// <param name="recipientId">Required parameter: Recipient id.</param>
+        /// <param name="request">Required parameter: Bank account data.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
         /// <returns>Returns the Models.GetRecipientResponse response from the API call.</returns>
-        public Models.GetRecipientResponse GetRecipient(
-                string recipientId)
+        public Models.GetRecipientResponse UpdateRecipientDefaultBankAccount(
+                string recipientId,
+                Models.UpdateRecipientBankAccountRequest request,
+                string idempotencyKey = null)
         {
-            Task<Models.GetRecipientResponse> t = this.GetRecipientAsync(recipientId);
+            Task<Models.GetRecipientResponse> t = this.UpdateRecipientDefaultBankAccountAsync(recipientId, request, idempotencyKey);
             ApiHelper.RunTaskSynchronously(t);
             return t.Result;
         }
 
         /// <summary>
-        /// Retrieves recipient information.
+        /// Updates the default bank account from a recipient.
         /// </summary>
-        /// <param name="recipientId">Required parameter: Recipiend id.</param>
+        /// <param name="recipientId">Required parameter: Recipient id.</param>
+        /// <param name="request">Required parameter: Bank account data.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
         /// <param name="cancellationToken"> cancellationToken. </param>
         /// <returns>Returns the Models.GetRecipientResponse response from the API call.</returns>
-        public async Task<Models.GetRecipientResponse> GetRecipientAsync(
+        public async Task<Models.GetRecipientResponse> UpdateRecipientDefaultBankAccountAsync(
                 string recipientId,
+                Models.UpdateRecipientBankAccountRequest request,
+                string idempotencyKey = null,
                 CancellationToken cancellationToken = default)
         {
             // the base uri for api requests.
@@ -1072,7 +721,7 @@ namespace PagarmeApiSDK.Standard.Controllers
 
             // prepare query string for API call.
             StringBuilder queryBuilder = new StringBuilder(baseUri);
-            queryBuilder.Append("/recipients/{recipient_id}");
+            queryBuilder.Append("/recipients/{recipient_id}/default-bank-account");
 
             // process optional template parameters.
             ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
@@ -1085,10 +734,15 @@ namespace PagarmeApiSDK.Standard.Controllers
             {
                 { "user-agent", this.UserAgent },
                 { "accept", "application/json" },
+                { "content-type", "application/json; charset=utf-8" },
+                { "idempotency-key", idempotencyKey },
             };
 
+            // append body params.
+            var bodyText = ApiHelper.JsonSerialize(request);
+
             // prepare the API call request to fetch the response.
-            HttpRequest httpRequest = this.GetClientInstance().Get(queryBuilder.ToString(), headers);
+            HttpRequest httpRequest = this.GetClientInstance().PatchBody(queryBuilder.ToString(), headers, bodyText);
 
             httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
 
@@ -1100,6 +754,72 @@ namespace PagarmeApiSDK.Standard.Controllers
             this.ValidateResponse(response, context);
 
             return ApiHelper.JsonDeserialize<Models.GetRecipientResponse>(response.Body);
+        }
+
+        /// <summary>
+        /// CreateWithdraw EndPoint.
+        /// </summary>
+        /// <param name="recipientId">Required parameter: Example: .</param>
+        /// <param name="request">Required parameter: Example: .</param>
+        /// <returns>Returns the Models.GetWithdrawResponse response from the API call.</returns>
+        public Models.GetWithdrawResponse CreateWithdraw(
+                string recipientId,
+                Models.CreateWithdrawRequest request)
+        {
+            Task<Models.GetWithdrawResponse> t = this.CreateWithdrawAsync(recipientId, request);
+            ApiHelper.RunTaskSynchronously(t);
+            return t.Result;
+        }
+
+        /// <summary>
+        /// CreateWithdraw EndPoint.
+        /// </summary>
+        /// <param name="recipientId">Required parameter: Example: .</param>
+        /// <param name="request">Required parameter: Example: .</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetWithdrawResponse response from the API call.</returns>
+        public async Task<Models.GetWithdrawResponse> CreateWithdrawAsync(
+                string recipientId,
+                Models.CreateWithdrawRequest request,
+                CancellationToken cancellationToken = default)
+        {
+            // the base uri for api requests.
+            string baseUri = this.Config.GetBaseUri();
+
+            // prepare query string for API call.
+            StringBuilder queryBuilder = new StringBuilder(baseUri);
+            queryBuilder.Append("/recipients/{recipient_id}/withdrawals");
+
+            // process optional template parameters.
+            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
+            {
+                { "recipient_id", recipientId },
+            });
+
+            // append request with appropriate headers and parameters
+            var headers = new Dictionary<string, string>()
+            {
+                { "user-agent", this.UserAgent },
+                { "accept", "application/json" },
+                { "content-type", "application/json; charset=utf-8" },
+            };
+
+            // append body params.
+            var bodyText = ApiHelper.JsonSerialize(request);
+
+            // prepare the API call request to fetch the response.
+            HttpRequest httpRequest = this.GetClientInstance().PostBody(queryBuilder.ToString(), headers, bodyText);
+
+            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
+
+            // invoke request and get response.
+            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+            HttpContext context = new HttpContext(httpRequest, response);
+
+            // handle errors defined at the API level.
+            this.ValidateResponse(response, context);
+
+            return ApiHelper.JsonDeserialize<Models.GetWithdrawResponse>(response.Body);
         }
 
         /// <summary>
@@ -1158,94 +878,6 @@ namespace PagarmeApiSDK.Standard.Controllers
             this.ValidateResponse(response, context);
 
             return ApiHelper.JsonDeserialize<Models.GetBalanceResponse>(response.Body);
-        }
-
-        /// <summary>
-        /// Gets a paginated list of transfers for the recipient.
-        /// </summary>
-        /// <param name="recipientId">Required parameter: Example: .</param>
-        /// <param name="page">Optional parameter: Example: .</param>
-        /// <param name="size">Optional parameter: Example: .</param>
-        /// <param name="status">Optional parameter: Example: .</param>
-        /// <param name="createdSince">Optional parameter: Example: .</param>
-        /// <param name="createdUntil">Optional parameter: Example: .</param>
-        /// <returns>Returns the Models.ListWithdrawals response from the API call.</returns>
-        public Models.ListWithdrawals GetWithdrawals(
-                string recipientId,
-                int? page = null,
-                int? size = null,
-                string status = null,
-                DateTime? createdSince = null,
-                DateTime? createdUntil = null)
-        {
-            Task<Models.ListWithdrawals> t = this.GetWithdrawalsAsync(recipientId, page, size, status, createdSince, createdUntil);
-            ApiHelper.RunTaskSynchronously(t);
-            return t.Result;
-        }
-
-        /// <summary>
-        /// Gets a paginated list of transfers for the recipient.
-        /// </summary>
-        /// <param name="recipientId">Required parameter: Example: .</param>
-        /// <param name="page">Optional parameter: Example: .</param>
-        /// <param name="size">Optional parameter: Example: .</param>
-        /// <param name="status">Optional parameter: Example: .</param>
-        /// <param name="createdSince">Optional parameter: Example: .</param>
-        /// <param name="createdUntil">Optional parameter: Example: .</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.ListWithdrawals response from the API call.</returns>
-        public async Task<Models.ListWithdrawals> GetWithdrawalsAsync(
-                string recipientId,
-                int? page = null,
-                int? size = null,
-                string status = null,
-                DateTime? createdSince = null,
-                DateTime? createdUntil = null,
-                CancellationToken cancellationToken = default)
-        {
-            // the base uri for api requests.
-            string baseUri = this.Config.GetBaseUri();
-
-            // prepare query string for API call.
-            StringBuilder queryBuilder = new StringBuilder(baseUri);
-            queryBuilder.Append("/recipients/{recipient_id}/withdrawals");
-
-            // process optional template parameters.
-            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
-            {
-                { "recipient_id", recipientId },
-            });
-
-            // prepare specfied query parameters.
-            var queryParams = new Dictionary<string, object>()
-            {
-                { "page", page },
-                { "size", size },
-                { "status", status },
-                { "created_since", createdSince.HasValue ? createdSince.Value.ToString("yyyy'-'MM'-'dd'T'HH':'mm':'ss.FFFFFFFK") : null },
-                { "created_until", createdUntil.HasValue ? createdUntil.Value.ToString("yyyy'-'MM'-'dd'T'HH':'mm':'ss.FFFFFFFK") : null },
-            };
-
-            // append request with appropriate headers and parameters
-            var headers = new Dictionary<string, string>()
-            {
-                { "user-agent", this.UserAgent },
-                { "accept", "application/json" },
-            };
-
-            // prepare the API call request to fetch the response.
-            HttpRequest httpRequest = this.GetClientInstance().Get(queryBuilder.ToString(), headers, queryParameters: queryParams);
-
-            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
-
-            // invoke request and get response.
-            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
-            HttpContext context = new HttpContext(httpRequest, response);
-
-            // handle errors defined at the API level.
-            this.ValidateResponse(response, context);
-
-            return ApiHelper.JsonDeserialize<Models.ListWithdrawals>(response.Body);
         }
 
         /// <summary>
@@ -1378,6 +1010,374 @@ namespace PagarmeApiSDK.Standard.Controllers
             this.ValidateResponse(response, context);
 
             return ApiHelper.JsonDeserialize<Models.GetRecipientResponse>(response.Body);
+        }
+
+        /// <summary>
+        /// Updates recipient metadata.
+        /// </summary>
+        /// <param name="recipientId">Required parameter: Recipient id.</param>
+        /// <param name="request">Required parameter: Metadata.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <returns>Returns the Models.GetRecipientResponse response from the API call.</returns>
+        public Models.GetRecipientResponse UpdateAutomaticAnticipationSettings(
+                string recipientId,
+                Models.UpdateAutomaticAnticipationSettingsRequest request,
+                string idempotencyKey = null)
+        {
+            Task<Models.GetRecipientResponse> t = this.UpdateAutomaticAnticipationSettingsAsync(recipientId, request, idempotencyKey);
+            ApiHelper.RunTaskSynchronously(t);
+            return t.Result;
+        }
+
+        /// <summary>
+        /// Updates recipient metadata.
+        /// </summary>
+        /// <param name="recipientId">Required parameter: Recipient id.</param>
+        /// <param name="request">Required parameter: Metadata.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetRecipientResponse response from the API call.</returns>
+        public async Task<Models.GetRecipientResponse> UpdateAutomaticAnticipationSettingsAsync(
+                string recipientId,
+                Models.UpdateAutomaticAnticipationSettingsRequest request,
+                string idempotencyKey = null,
+                CancellationToken cancellationToken = default)
+        {
+            // the base uri for api requests.
+            string baseUri = this.Config.GetBaseUri();
+
+            // prepare query string for API call.
+            StringBuilder queryBuilder = new StringBuilder(baseUri);
+            queryBuilder.Append("/recipients/{recipient_id}/automatic-anticipation-settings");
+
+            // process optional template parameters.
+            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
+            {
+                { "recipient_id", recipientId },
+            });
+
+            // append request with appropriate headers and parameters
+            var headers = new Dictionary<string, string>()
+            {
+                { "user-agent", this.UserAgent },
+                { "accept", "application/json" },
+                { "content-type", "application/json; charset=utf-8" },
+                { "idempotency-key", idempotencyKey },
+            };
+
+            // append body params.
+            var bodyText = ApiHelper.JsonSerialize(request);
+
+            // prepare the API call request to fetch the response.
+            HttpRequest httpRequest = this.GetClientInstance().PatchBody(queryBuilder.ToString(), headers, bodyText);
+
+            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
+
+            // invoke request and get response.
+            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+            HttpContext context = new HttpContext(httpRequest, response);
+
+            // handle errors defined at the API level.
+            this.ValidateResponse(response, context);
+
+            return ApiHelper.JsonDeserialize<Models.GetRecipientResponse>(response.Body);
+        }
+
+        /// <summary>
+        /// Retrieves recipient information.
+        /// </summary>
+        /// <param name="recipientId">Required parameter: Recipiend id.</param>
+        /// <returns>Returns the Models.GetRecipientResponse response from the API call.</returns>
+        public Models.GetRecipientResponse GetRecipient(
+                string recipientId)
+        {
+            Task<Models.GetRecipientResponse> t = this.GetRecipientAsync(recipientId);
+            ApiHelper.RunTaskSynchronously(t);
+            return t.Result;
+        }
+
+        /// <summary>
+        /// Retrieves recipient information.
+        /// </summary>
+        /// <param name="recipientId">Required parameter: Recipiend id.</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetRecipientResponse response from the API call.</returns>
+        public async Task<Models.GetRecipientResponse> GetRecipientAsync(
+                string recipientId,
+                CancellationToken cancellationToken = default)
+        {
+            // the base uri for api requests.
+            string baseUri = this.Config.GetBaseUri();
+
+            // prepare query string for API call.
+            StringBuilder queryBuilder = new StringBuilder(baseUri);
+            queryBuilder.Append("/recipients/{recipient_id}");
+
+            // process optional template parameters.
+            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
+            {
+                { "recipient_id", recipientId },
+            });
+
+            // append request with appropriate headers and parameters
+            var headers = new Dictionary<string, string>()
+            {
+                { "user-agent", this.UserAgent },
+                { "accept", "application/json" },
+            };
+
+            // prepare the API call request to fetch the response.
+            HttpRequest httpRequest = this.GetClientInstance().Get(queryBuilder.ToString(), headers);
+
+            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
+
+            // invoke request and get response.
+            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+            HttpContext context = new HttpContext(httpRequest, response);
+
+            // handle errors defined at the API level.
+            this.ValidateResponse(response, context);
+
+            return ApiHelper.JsonDeserialize<Models.GetRecipientResponse>(response.Body);
+        }
+
+        /// <summary>
+        /// Gets a paginated list of transfers for the recipient.
+        /// </summary>
+        /// <param name="recipientId">Required parameter: Example: .</param>
+        /// <param name="page">Optional parameter: Example: .</param>
+        /// <param name="size">Optional parameter: Example: .</param>
+        /// <param name="status">Optional parameter: Example: .</param>
+        /// <param name="createdSince">Optional parameter: Example: .</param>
+        /// <param name="createdUntil">Optional parameter: Example: .</param>
+        /// <returns>Returns the Models.ListWithdrawals response from the API call.</returns>
+        public Models.ListWithdrawals GetWithdrawals(
+                string recipientId,
+                int? page = null,
+                int? size = null,
+                string status = null,
+                DateTime? createdSince = null,
+                DateTime? createdUntil = null)
+        {
+            Task<Models.ListWithdrawals> t = this.GetWithdrawalsAsync(recipientId, page, size, status, createdSince, createdUntil);
+            ApiHelper.RunTaskSynchronously(t);
+            return t.Result;
+        }
+
+        /// <summary>
+        /// Gets a paginated list of transfers for the recipient.
+        /// </summary>
+        /// <param name="recipientId">Required parameter: Example: .</param>
+        /// <param name="page">Optional parameter: Example: .</param>
+        /// <param name="size">Optional parameter: Example: .</param>
+        /// <param name="status">Optional parameter: Example: .</param>
+        /// <param name="createdSince">Optional parameter: Example: .</param>
+        /// <param name="createdUntil">Optional parameter: Example: .</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.ListWithdrawals response from the API call.</returns>
+        public async Task<Models.ListWithdrawals> GetWithdrawalsAsync(
+                string recipientId,
+                int? page = null,
+                int? size = null,
+                string status = null,
+                DateTime? createdSince = null,
+                DateTime? createdUntil = null,
+                CancellationToken cancellationToken = default)
+        {
+            // the base uri for api requests.
+            string baseUri = this.Config.GetBaseUri();
+
+            // prepare query string for API call.
+            StringBuilder queryBuilder = new StringBuilder(baseUri);
+            queryBuilder.Append("/recipients/{recipient_id}/withdrawals");
+
+            // process optional template parameters.
+            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
+            {
+                { "recipient_id", recipientId },
+            });
+
+            // prepare specfied query parameters.
+            var queryParams = new Dictionary<string, object>()
+            {
+                { "page", page },
+                { "size", size },
+                { "status", status },
+                { "created_since", createdSince.HasValue ? createdSince.Value.ToString("yyyy'-'MM'-'dd'T'HH':'mm':'ss.FFFFFFFK") : null },
+                { "created_until", createdUntil.HasValue ? createdUntil.Value.ToString("yyyy'-'MM'-'dd'T'HH':'mm':'ss.FFFFFFFK") : null },
+            };
+
+            // append request with appropriate headers and parameters
+            var headers = new Dictionary<string, string>()
+            {
+                { "user-agent", this.UserAgent },
+                { "accept", "application/json" },
+            };
+
+            // prepare the API call request to fetch the response.
+            HttpRequest httpRequest = this.GetClientInstance().Get(queryBuilder.ToString(), headers, queryParameters: queryParams);
+
+            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
+
+            // invoke request and get response.
+            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+            HttpContext context = new HttpContext(httpRequest, response);
+
+            // handle errors defined at the API level.
+            this.ValidateResponse(response, context);
+
+            return ApiHelper.JsonDeserialize<Models.ListWithdrawals>(response.Body);
+        }
+
+        /// <summary>
+        /// GetWithdrawById EndPoint.
+        /// </summary>
+        /// <param name="recipientId">Required parameter: Example: .</param>
+        /// <param name="withdrawalId">Required parameter: Example: .</param>
+        /// <returns>Returns the Models.GetWithdrawResponse response from the API call.</returns>
+        public Models.GetWithdrawResponse GetWithdrawById(
+                string recipientId,
+                string withdrawalId)
+        {
+            Task<Models.GetWithdrawResponse> t = this.GetWithdrawByIdAsync(recipientId, withdrawalId);
+            ApiHelper.RunTaskSynchronously(t);
+            return t.Result;
+        }
+
+        /// <summary>
+        /// GetWithdrawById EndPoint.
+        /// </summary>
+        /// <param name="recipientId">Required parameter: Example: .</param>
+        /// <param name="withdrawalId">Required parameter: Example: .</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetWithdrawResponse response from the API call.</returns>
+        public async Task<Models.GetWithdrawResponse> GetWithdrawByIdAsync(
+                string recipientId,
+                string withdrawalId,
+                CancellationToken cancellationToken = default)
+        {
+            // the base uri for api requests.
+            string baseUri = this.Config.GetBaseUri();
+
+            // prepare query string for API call.
+            StringBuilder queryBuilder = new StringBuilder(baseUri);
+            queryBuilder.Append("/recipients/{recipient_id}/withdrawals/{withdrawal_id}");
+
+            // process optional template parameters.
+            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
+            {
+                { "recipient_id", recipientId },
+                { "withdrawal_id", withdrawalId },
+            });
+
+            // append request with appropriate headers and parameters
+            var headers = new Dictionary<string, string>()
+            {
+                { "user-agent", this.UserAgent },
+                { "accept", "application/json" },
+            };
+
+            // prepare the API call request to fetch the response.
+            HttpRequest httpRequest = this.GetClientInstance().Get(queryBuilder.ToString(), headers);
+
+            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
+
+            // invoke request and get response.
+            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+            HttpContext context = new HttpContext(httpRequest, response);
+
+            // handle errors defined at the API level.
+            this.ValidateResponse(response, context);
+
+            return ApiHelper.JsonDeserialize<Models.GetWithdrawResponse>(response.Body);
+        }
+
+        /// <summary>
+        /// Gets a paginated list of transfers for the recipient.
+        /// </summary>
+        /// <param name="recipientId">Required parameter: Recipient id.</param>
+        /// <param name="page">Optional parameter: Page number.</param>
+        /// <param name="size">Optional parameter: Page size.</param>
+        /// <param name="status">Optional parameter: Filter for transfer status.</param>
+        /// <param name="createdSince">Optional parameter: Filter for start range of transfer creation date.</param>
+        /// <param name="createdUntil">Optional parameter: Filter for end range of transfer creation date.</param>
+        /// <returns>Returns the Models.ListTransferResponse response from the API call.</returns>
+        public Models.ListTransferResponse GetTransfers(
+                string recipientId,
+                int? page = null,
+                int? size = null,
+                string status = null,
+                DateTime? createdSince = null,
+                DateTime? createdUntil = null)
+        {
+            Task<Models.ListTransferResponse> t = this.GetTransfersAsync(recipientId, page, size, status, createdSince, createdUntil);
+            ApiHelper.RunTaskSynchronously(t);
+            return t.Result;
+        }
+
+        /// <summary>
+        /// Gets a paginated list of transfers for the recipient.
+        /// </summary>
+        /// <param name="recipientId">Required parameter: Recipient id.</param>
+        /// <param name="page">Optional parameter: Page number.</param>
+        /// <param name="size">Optional parameter: Page size.</param>
+        /// <param name="status">Optional parameter: Filter for transfer status.</param>
+        /// <param name="createdSince">Optional parameter: Filter for start range of transfer creation date.</param>
+        /// <param name="createdUntil">Optional parameter: Filter for end range of transfer creation date.</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.ListTransferResponse response from the API call.</returns>
+        public async Task<Models.ListTransferResponse> GetTransfersAsync(
+                string recipientId,
+                int? page = null,
+                int? size = null,
+                string status = null,
+                DateTime? createdSince = null,
+                DateTime? createdUntil = null,
+                CancellationToken cancellationToken = default)
+        {
+            // the base uri for api requests.
+            string baseUri = this.Config.GetBaseUri();
+
+            // prepare query string for API call.
+            StringBuilder queryBuilder = new StringBuilder(baseUri);
+            queryBuilder.Append("/recipients/{recipient_id}/transfers");
+
+            // process optional template parameters.
+            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
+            {
+                { "recipient_id", recipientId },
+            });
+
+            // prepare specfied query parameters.
+            var queryParams = new Dictionary<string, object>()
+            {
+                { "page", page },
+                { "size", size },
+                { "status", status },
+                { "created_since", createdSince.HasValue ? createdSince.Value.ToString("yyyy'-'MM'-'dd'T'HH':'mm':'ss.FFFFFFFK") : null },
+                { "created_until", createdUntil.HasValue ? createdUntil.Value.ToString("yyyy'-'MM'-'dd'T'HH':'mm':'ss.FFFFFFFK") : null },
+            };
+
+            // append request with appropriate headers and parameters
+            var headers = new Dictionary<string, string>()
+            {
+                { "user-agent", this.UserAgent },
+                { "accept", "application/json" },
+            };
+
+            // prepare the API call request to fetch the response.
+            HttpRequest httpRequest = this.GetClientInstance().Get(queryBuilder.ToString(), headers, queryParameters: queryParams);
+
+            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
+
+            // invoke request and get response.
+            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+            HttpContext context = new HttpContext(httpRequest, response);
+
+            // handle errors defined at the API level.
+            this.ValidateResponse(response, context);
+
+            return ApiHelper.JsonDeserialize<Models.ListTransferResponse>(response.Body);
         }
 
         /// <summary>

--- a/PagarmeApiSDK.Standard/Controllers/SubscriptionsController.cs
+++ b/PagarmeApiSDK.Standard/Controllers/SubscriptionsController.cs
@@ -100,355 +100,6 @@ namespace PagarmeApiSDK.Standard.Controllers
         }
 
         /// <summary>
-        /// Updates the credit card from a subscription.
-        /// </summary>
-        /// <param name="subscriptionId">Required parameter: Subscription id.</param>
-        /// <param name="request">Required parameter: Request for updating a card.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <returns>Returns the Models.GetSubscriptionResponse response from the API call.</returns>
-        public Models.GetSubscriptionResponse UpdateSubscriptionCard(
-                string subscriptionId,
-                Models.UpdateSubscriptionCardRequest request,
-                string idempotencyKey = null)
-        {
-            Task<Models.GetSubscriptionResponse> t = this.UpdateSubscriptionCardAsync(subscriptionId, request, idempotencyKey);
-            ApiHelper.RunTaskSynchronously(t);
-            return t.Result;
-        }
-
-        /// <summary>
-        /// Updates the credit card from a subscription.
-        /// </summary>
-        /// <param name="subscriptionId">Required parameter: Subscription id.</param>
-        /// <param name="request">Required parameter: Request for updating a card.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetSubscriptionResponse response from the API call.</returns>
-        public async Task<Models.GetSubscriptionResponse> UpdateSubscriptionCardAsync(
-                string subscriptionId,
-                Models.UpdateSubscriptionCardRequest request,
-                string idempotencyKey = null,
-                CancellationToken cancellationToken = default)
-        {
-            // the base uri for api requests.
-            string baseUri = this.Config.GetBaseUri();
-
-            // prepare query string for API call.
-            StringBuilder queryBuilder = new StringBuilder(baseUri);
-            queryBuilder.Append("/subscriptions/{subscription_id}/card");
-
-            // process optional template parameters.
-            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
-            {
-                { "subscription_id", subscriptionId },
-            });
-
-            // append request with appropriate headers and parameters
-            var headers = new Dictionary<string, string>()
-            {
-                { "user-agent", this.UserAgent },
-                { "accept", "application/json" },
-                { "content-type", "application/json; charset=utf-8" },
-                { "idempotency-key", idempotencyKey },
-            };
-
-            // append body params.
-            var bodyText = ApiHelper.JsonSerialize(request);
-
-            // prepare the API call request to fetch the response.
-            HttpRequest httpRequest = this.GetClientInstance().PatchBody(queryBuilder.ToString(), headers, bodyText);
-
-            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
-
-            // invoke request and get response.
-            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
-            HttpContext context = new HttpContext(httpRequest, response);
-
-            // handle errors defined at the API level.
-            this.ValidateResponse(response, context);
-
-            return ApiHelper.JsonDeserialize<Models.GetSubscriptionResponse>(response.Body);
-        }
-
-        /// <summary>
-        /// Deletes a usage.
-        /// </summary>
-        /// <param name="subscriptionId">Required parameter: The subscription id.</param>
-        /// <param name="itemId">Required parameter: The subscription item id.</param>
-        /// <param name="usageId">Required parameter: The usage id.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <returns>Returns the Models.GetUsageResponse response from the API call.</returns>
-        public Models.GetUsageResponse DeleteUsage(
-                string subscriptionId,
-                string itemId,
-                string usageId,
-                string idempotencyKey = null)
-        {
-            Task<Models.GetUsageResponse> t = this.DeleteUsageAsync(subscriptionId, itemId, usageId, idempotencyKey);
-            ApiHelper.RunTaskSynchronously(t);
-            return t.Result;
-        }
-
-        /// <summary>
-        /// Deletes a usage.
-        /// </summary>
-        /// <param name="subscriptionId">Required parameter: The subscription id.</param>
-        /// <param name="itemId">Required parameter: The subscription item id.</param>
-        /// <param name="usageId">Required parameter: The usage id.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetUsageResponse response from the API call.</returns>
-        public async Task<Models.GetUsageResponse> DeleteUsageAsync(
-                string subscriptionId,
-                string itemId,
-                string usageId,
-                string idempotencyKey = null,
-                CancellationToken cancellationToken = default)
-        {
-            // the base uri for api requests.
-            string baseUri = this.Config.GetBaseUri();
-
-            // prepare query string for API call.
-            StringBuilder queryBuilder = new StringBuilder(baseUri);
-            queryBuilder.Append("/subscriptions/{subscription_id}/items/{item_id}/usages/{usage_id}");
-
-            // process optional template parameters.
-            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
-            {
-                { "subscription_id", subscriptionId },
-                { "item_id", itemId },
-                { "usage_id", usageId },
-            });
-
-            // append request with appropriate headers and parameters
-            var headers = new Dictionary<string, string>()
-            {
-                { "user-agent", this.UserAgent },
-                { "accept", "application/json" },
-                { "idempotency-key", idempotencyKey },
-            };
-
-            // prepare the API call request to fetch the response.
-            HttpRequest httpRequest = this.GetClientInstance().Delete(queryBuilder.ToString(), headers, null);
-
-            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
-
-            // invoke request and get response.
-            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
-            HttpContext context = new HttpContext(httpRequest, response);
-
-            // handle errors defined at the API level.
-            this.ValidateResponse(response, context);
-
-            return ApiHelper.JsonDeserialize<Models.GetUsageResponse>(response.Body);
-        }
-
-        /// <summary>
-        /// Creates a discount.
-        /// </summary>
-        /// <param name="subscriptionId">Required parameter: Subscription id.</param>
-        /// <param name="request">Required parameter: Request for creating a discount.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <returns>Returns the Models.GetDiscountResponse response from the API call.</returns>
-        public Models.GetDiscountResponse CreateDiscount(
-                string subscriptionId,
-                Models.CreateDiscountRequest request,
-                string idempotencyKey = null)
-        {
-            Task<Models.GetDiscountResponse> t = this.CreateDiscountAsync(subscriptionId, request, idempotencyKey);
-            ApiHelper.RunTaskSynchronously(t);
-            return t.Result;
-        }
-
-        /// <summary>
-        /// Creates a discount.
-        /// </summary>
-        /// <param name="subscriptionId">Required parameter: Subscription id.</param>
-        /// <param name="request">Required parameter: Request for creating a discount.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetDiscountResponse response from the API call.</returns>
-        public async Task<Models.GetDiscountResponse> CreateDiscountAsync(
-                string subscriptionId,
-                Models.CreateDiscountRequest request,
-                string idempotencyKey = null,
-                CancellationToken cancellationToken = default)
-        {
-            // the base uri for api requests.
-            string baseUri = this.Config.GetBaseUri();
-
-            // prepare query string for API call.
-            StringBuilder queryBuilder = new StringBuilder(baseUri);
-            queryBuilder.Append("/subscriptions/{subscription_id}/discounts");
-
-            // process optional template parameters.
-            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
-            {
-                { "subscription_id", subscriptionId },
-            });
-
-            // append request with appropriate headers and parameters
-            var headers = new Dictionary<string, string>()
-            {
-                { "user-agent", this.UserAgent },
-                { "accept", "application/json" },
-                { "content-type", "application/json; charset=utf-8" },
-                { "idempotency-key", idempotencyKey },
-            };
-
-            // append body params.
-            var bodyText = ApiHelper.JsonSerialize(request);
-
-            // prepare the API call request to fetch the response.
-            HttpRequest httpRequest = this.GetClientInstance().PostBody(queryBuilder.ToString(), headers, bodyText);
-
-            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
-
-            // invoke request and get response.
-            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
-            HttpContext context = new HttpContext(httpRequest, response);
-
-            // handle errors defined at the API level.
-            this.ValidateResponse(response, context);
-
-            return ApiHelper.JsonDeserialize<Models.GetDiscountResponse>(response.Body);
-        }
-
-        /// <summary>
-        /// Create Usage.
-        /// </summary>
-        /// <param name="subscriptionId">Required parameter: Subscription id.</param>
-        /// <param name="itemId">Required parameter: Item id.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <returns>Returns the Models.GetUsageResponse response from the API call.</returns>
-        public Models.GetUsageResponse CreateAnUsage(
-                string subscriptionId,
-                string itemId,
-                string idempotencyKey = null)
-        {
-            Task<Models.GetUsageResponse> t = this.CreateAnUsageAsync(subscriptionId, itemId, idempotencyKey);
-            ApiHelper.RunTaskSynchronously(t);
-            return t.Result;
-        }
-
-        /// <summary>
-        /// Create Usage.
-        /// </summary>
-        /// <param name="subscriptionId">Required parameter: Subscription id.</param>
-        /// <param name="itemId">Required parameter: Item id.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetUsageResponse response from the API call.</returns>
-        public async Task<Models.GetUsageResponse> CreateAnUsageAsync(
-                string subscriptionId,
-                string itemId,
-                string idempotencyKey = null,
-                CancellationToken cancellationToken = default)
-        {
-            // the base uri for api requests.
-            string baseUri = this.Config.GetBaseUri();
-
-            // prepare query string for API call.
-            StringBuilder queryBuilder = new StringBuilder(baseUri);
-            queryBuilder.Append("/subscriptions/{subscription_id}/items/{item_id}/usages");
-
-            // process optional template parameters.
-            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
-            {
-                { "subscription_id", subscriptionId },
-                { "item_id", itemId },
-            });
-
-            // append request with appropriate headers and parameters
-            var headers = new Dictionary<string, string>()
-            {
-                { "user-agent", this.UserAgent },
-                { "accept", "application/json" },
-                { "idempotency-key", idempotencyKey },
-            };
-
-            // prepare the API call request to fetch the response.
-            HttpRequest httpRequest = this.GetClientInstance().Post(queryBuilder.ToString(), headers, null);
-
-            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
-
-            // invoke request and get response.
-            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
-            HttpContext context = new HttpContext(httpRequest, response);
-
-            // handle errors defined at the API level.
-            this.ValidateResponse(response, context);
-
-            return ApiHelper.JsonDeserialize<Models.GetUsageResponse>(response.Body);
-        }
-
-        /// <summary>
-        /// UpdateCurrentCycleStatus EndPoint.
-        /// </summary>
-        /// <param name="subscriptionId">Required parameter: Subscription Id.</param>
-        /// <param name="request">Required parameter: Request for updating the end date of the subscription current status.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        public void UpdateCurrentCycleStatus(
-                string subscriptionId,
-                Models.UpdateCurrentCycleStatusRequest request,
-                string idempotencyKey = null)
-        {
-            Task t = this.UpdateCurrentCycleStatusAsync(subscriptionId, request, idempotencyKey);
-            ApiHelper.RunTaskSynchronously(t);
-        }
-
-        /// <summary>
-        /// UpdateCurrentCycleStatus EndPoint.
-        /// </summary>
-        /// <param name="subscriptionId">Required parameter: Subscription Id.</param>
-        /// <param name="request">Required parameter: Request for updating the end date of the subscription current status.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the void response from the API call.</returns>
-        public async Task UpdateCurrentCycleStatusAsync(
-                string subscriptionId,
-                Models.UpdateCurrentCycleStatusRequest request,
-                string idempotencyKey = null,
-                CancellationToken cancellationToken = default)
-        {
-            // the base uri for api requests.
-            string baseUri = this.Config.GetBaseUri();
-
-            // prepare query string for API call.
-            StringBuilder queryBuilder = new StringBuilder(baseUri);
-            queryBuilder.Append("/subscriptions/{subscription_id}/cycle-status");
-
-            // process optional template parameters.
-            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
-            {
-                { "subscription_id", subscriptionId },
-            });
-
-            // append request with appropriate headers and parameters
-            var headers = new Dictionary<string, string>()
-            {
-                { "user-agent", this.UserAgent },
-                { "content-type", "application/json; charset=utf-8" },
-                { "idempotency-key", idempotencyKey },
-            };
-
-            // append body params.
-            var bodyText = ApiHelper.JsonSerialize(request);
-
-            // prepare the API call request to fetch the response.
-            HttpRequest httpRequest = this.GetClientInstance().PatchBody(queryBuilder.ToString(), headers, bodyText);
-
-            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
-
-            // invoke request and get response.
-            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
-            HttpContext context = new HttpContext(httpRequest, response);
-
-            // handle errors defined at the API level.
-            this.ValidateResponse(response, context);
-        }
-
-        /// <summary>
         /// Deletes a discount.
         /// </summary>
         /// <param name="subscriptionId">Required parameter: Subscription id.</param>
@@ -514,243 +165,6 @@ namespace PagarmeApiSDK.Standard.Controllers
             this.ValidateResponse(response, context);
 
             return ApiHelper.JsonDeserialize<Models.GetDiscountResponse>(response.Body);
-        }
-
-        /// <summary>
-        /// Get Subscription Items.
-        /// </summary>
-        /// <param name="subscriptionId">Required parameter: The subscription id.</param>
-        /// <param name="page">Optional parameter: Page number.</param>
-        /// <param name="size">Optional parameter: Page size.</param>
-        /// <param name="name">Optional parameter: The item name.</param>
-        /// <param name="code">Optional parameter: Identification code in the client system.</param>
-        /// <param name="status">Optional parameter: The item statis.</param>
-        /// <param name="description">Optional parameter: The item description.</param>
-        /// <param name="createdSince">Optional parameter: Filter for item's creation date start range.</param>
-        /// <param name="createdUntil">Optional parameter: Filter for item's creation date end range.</param>
-        /// <returns>Returns the Models.ListSubscriptionItemsResponse response from the API call.</returns>
-        public Models.ListSubscriptionItemsResponse GetSubscriptionItems(
-                string subscriptionId,
-                int? page = null,
-                int? size = null,
-                string name = null,
-                string code = null,
-                string status = null,
-                string description = null,
-                string createdSince = null,
-                string createdUntil = null)
-        {
-            Task<Models.ListSubscriptionItemsResponse> t = this.GetSubscriptionItemsAsync(subscriptionId, page, size, name, code, status, description, createdSince, createdUntil);
-            ApiHelper.RunTaskSynchronously(t);
-            return t.Result;
-        }
-
-        /// <summary>
-        /// Get Subscription Items.
-        /// </summary>
-        /// <param name="subscriptionId">Required parameter: The subscription id.</param>
-        /// <param name="page">Optional parameter: Page number.</param>
-        /// <param name="size">Optional parameter: Page size.</param>
-        /// <param name="name">Optional parameter: The item name.</param>
-        /// <param name="code">Optional parameter: Identification code in the client system.</param>
-        /// <param name="status">Optional parameter: The item statis.</param>
-        /// <param name="description">Optional parameter: The item description.</param>
-        /// <param name="createdSince">Optional parameter: Filter for item's creation date start range.</param>
-        /// <param name="createdUntil">Optional parameter: Filter for item's creation date end range.</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.ListSubscriptionItemsResponse response from the API call.</returns>
-        public async Task<Models.ListSubscriptionItemsResponse> GetSubscriptionItemsAsync(
-                string subscriptionId,
-                int? page = null,
-                int? size = null,
-                string name = null,
-                string code = null,
-                string status = null,
-                string description = null,
-                string createdSince = null,
-                string createdUntil = null,
-                CancellationToken cancellationToken = default)
-        {
-            // the base uri for api requests.
-            string baseUri = this.Config.GetBaseUri();
-
-            // prepare query string for API call.
-            StringBuilder queryBuilder = new StringBuilder(baseUri);
-            queryBuilder.Append("/subscriptions/{subscription_id}/items");
-
-            // process optional template parameters.
-            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
-            {
-                { "subscription_id", subscriptionId },
-            });
-
-            // prepare specfied query parameters.
-            var queryParams = new Dictionary<string, object>()
-            {
-                { "page", page },
-                { "size", size },
-                { "name", name },
-                { "code", code },
-                { "status", status },
-                { "description", description },
-                { "created_since", createdSince },
-                { "created_until", createdUntil },
-            };
-
-            // append request with appropriate headers and parameters
-            var headers = new Dictionary<string, string>()
-            {
-                { "user-agent", this.UserAgent },
-                { "accept", "application/json" },
-            };
-
-            // prepare the API call request to fetch the response.
-            HttpRequest httpRequest = this.GetClientInstance().Get(queryBuilder.ToString(), headers, queryParameters: queryParams);
-
-            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
-
-            // invoke request and get response.
-            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
-            HttpContext context = new HttpContext(httpRequest, response);
-
-            // handle errors defined at the API level.
-            this.ValidateResponse(response, context);
-
-            return ApiHelper.JsonDeserialize<Models.ListSubscriptionItemsResponse>(response.Body);
-        }
-
-        /// <summary>
-        /// Updates the payment method from a subscription.
-        /// </summary>
-        /// <param name="subscriptionId">Required parameter: Subscription id.</param>
-        /// <param name="request">Required parameter: Request for updating the paymentmethod from a subscription.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <returns>Returns the Models.GetSubscriptionResponse response from the API call.</returns>
-        public Models.GetSubscriptionResponse UpdateSubscriptionPaymentMethod(
-                string subscriptionId,
-                Models.UpdateSubscriptionPaymentMethodRequest request,
-                string idempotencyKey = null)
-        {
-            Task<Models.GetSubscriptionResponse> t = this.UpdateSubscriptionPaymentMethodAsync(subscriptionId, request, idempotencyKey);
-            ApiHelper.RunTaskSynchronously(t);
-            return t.Result;
-        }
-
-        /// <summary>
-        /// Updates the payment method from a subscription.
-        /// </summary>
-        /// <param name="subscriptionId">Required parameter: Subscription id.</param>
-        /// <param name="request">Required parameter: Request for updating the paymentmethod from a subscription.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetSubscriptionResponse response from the API call.</returns>
-        public async Task<Models.GetSubscriptionResponse> UpdateSubscriptionPaymentMethodAsync(
-                string subscriptionId,
-                Models.UpdateSubscriptionPaymentMethodRequest request,
-                string idempotencyKey = null,
-                CancellationToken cancellationToken = default)
-        {
-            // the base uri for api requests.
-            string baseUri = this.Config.GetBaseUri();
-
-            // prepare query string for API call.
-            StringBuilder queryBuilder = new StringBuilder(baseUri);
-            queryBuilder.Append("/subscriptions/{subscription_id}/payment-method");
-
-            // process optional template parameters.
-            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
-            {
-                { "subscription_id", subscriptionId },
-            });
-
-            // append request with appropriate headers and parameters
-            var headers = new Dictionary<string, string>()
-            {
-                { "user-agent", this.UserAgent },
-                { "accept", "application/json" },
-                { "content-type", "application/json; charset=utf-8" },
-                { "idempotency-key", idempotencyKey },
-            };
-
-            // append body params.
-            var bodyText = ApiHelper.JsonSerialize(request);
-
-            // prepare the API call request to fetch the response.
-            HttpRequest httpRequest = this.GetClientInstance().PatchBody(queryBuilder.ToString(), headers, bodyText);
-
-            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
-
-            // invoke request and get response.
-            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
-            HttpContext context = new HttpContext(httpRequest, response);
-
-            // handle errors defined at the API level.
-            this.ValidateResponse(response, context);
-
-            return ApiHelper.JsonDeserialize<Models.GetSubscriptionResponse>(response.Body);
-        }
-
-        /// <summary>
-        /// Get Subscription Item.
-        /// </summary>
-        /// <param name="subscriptionId">Required parameter: Subscription Id.</param>
-        /// <param name="itemId">Required parameter: Item id.</param>
-        /// <returns>Returns the Models.GetSubscriptionItemResponse response from the API call.</returns>
-        public Models.GetSubscriptionItemResponse GetSubscriptionItem(
-                string subscriptionId,
-                string itemId)
-        {
-            Task<Models.GetSubscriptionItemResponse> t = this.GetSubscriptionItemAsync(subscriptionId, itemId);
-            ApiHelper.RunTaskSynchronously(t);
-            return t.Result;
-        }
-
-        /// <summary>
-        /// Get Subscription Item.
-        /// </summary>
-        /// <param name="subscriptionId">Required parameter: Subscription Id.</param>
-        /// <param name="itemId">Required parameter: Item id.</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetSubscriptionItemResponse response from the API call.</returns>
-        public async Task<Models.GetSubscriptionItemResponse> GetSubscriptionItemAsync(
-                string subscriptionId,
-                string itemId,
-                CancellationToken cancellationToken = default)
-        {
-            // the base uri for api requests.
-            string baseUri = this.Config.GetBaseUri();
-
-            // prepare query string for API call.
-            StringBuilder queryBuilder = new StringBuilder(baseUri);
-            queryBuilder.Append("/subscriptions/{subscription_id}/items/{item_id}");
-
-            // process optional template parameters.
-            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
-            {
-                { "subscription_id", subscriptionId },
-                { "item_id", itemId },
-            });
-
-            // append request with appropriate headers and parameters
-            var headers = new Dictionary<string, string>()
-            {
-                { "user-agent", this.UserAgent },
-                { "accept", "application/json" },
-            };
-
-            // prepare the API call request to fetch the response.
-            HttpRequest httpRequest = this.GetClientInstance().Get(queryBuilder.ToString(), headers);
-
-            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
-
-            // invoke request and get response.
-            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
-            HttpContext context = new HttpContext(httpRequest, response);
-
-            // handle errors defined at the API level.
-            this.ValidateResponse(response, context);
-
-            return ApiHelper.JsonDeserialize<Models.GetSubscriptionItemResponse>(response.Body);
         }
 
         /// <summary>
@@ -864,224 +278,6 @@ namespace PagarmeApiSDK.Standard.Controllers
             this.ValidateResponse(response, context);
 
             return ApiHelper.JsonDeserialize<Models.ListSubscriptionsResponse>(response.Body);
-        }
-
-        /// <summary>
-        /// Cancels a subscription.
-        /// </summary>
-        /// <param name="subscriptionId">Required parameter: Subscription id.</param>
-        /// <param name="request">Optional parameter: Request for cancelling a subscription.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <returns>Returns the Models.GetSubscriptionResponse response from the API call.</returns>
-        public Models.GetSubscriptionResponse CancelSubscription(
-                string subscriptionId,
-                Models.CreateCancelSubscriptionRequest request = null,
-                string idempotencyKey = null)
-        {
-            Task<Models.GetSubscriptionResponse> t = this.CancelSubscriptionAsync(subscriptionId, request, idempotencyKey);
-            ApiHelper.RunTaskSynchronously(t);
-            return t.Result;
-        }
-
-        /// <summary>
-        /// Cancels a subscription.
-        /// </summary>
-        /// <param name="subscriptionId">Required parameter: Subscription id.</param>
-        /// <param name="request">Optional parameter: Request for cancelling a subscription.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetSubscriptionResponse response from the API call.</returns>
-        public async Task<Models.GetSubscriptionResponse> CancelSubscriptionAsync(
-                string subscriptionId,
-                Models.CreateCancelSubscriptionRequest request = null,
-                string idempotencyKey = null,
-                CancellationToken cancellationToken = default)
-        {
-            // the base uri for api requests.
-            string baseUri = this.Config.GetBaseUri();
-
-            // prepare query string for API call.
-            StringBuilder queryBuilder = new StringBuilder(baseUri);
-            queryBuilder.Append("/subscriptions/{subscription_id}");
-
-            // process optional template parameters.
-            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
-            {
-                { "subscription_id", subscriptionId },
-            });
-
-            // append request with appropriate headers and parameters
-            var headers = new Dictionary<string, string>()
-            {
-                { "user-agent", this.UserAgent },
-                { "accept", "application/json" },
-                { "content-type", "application/json; charset=utf-8" },
-                { "idempotency-key", idempotencyKey },
-            };
-
-            // append body params.
-            var bodyText = ApiHelper.JsonSerialize(request);
-
-            // prepare the API call request to fetch the response.
-            HttpRequest httpRequest = this.GetClientInstance().DeleteBody(queryBuilder.ToString(), headers, bodyText);
-
-            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
-
-            // invoke request and get response.
-            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
-            HttpContext context = new HttpContext(httpRequest, response);
-
-            // handle errors defined at the API level.
-            this.ValidateResponse(response, context);
-
-            return ApiHelper.JsonDeserialize<Models.GetSubscriptionResponse>(response.Body);
-        }
-
-        /// <summary>
-        /// Creates a increment.
-        /// </summary>
-        /// <param name="subscriptionId">Required parameter: Subscription id.</param>
-        /// <param name="request">Required parameter: Request for creating a increment.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <returns>Returns the Models.GetIncrementResponse response from the API call.</returns>
-        public Models.GetIncrementResponse CreateIncrement(
-                string subscriptionId,
-                Models.CreateIncrementRequest request,
-                string idempotencyKey = null)
-        {
-            Task<Models.GetIncrementResponse> t = this.CreateIncrementAsync(subscriptionId, request, idempotencyKey);
-            ApiHelper.RunTaskSynchronously(t);
-            return t.Result;
-        }
-
-        /// <summary>
-        /// Creates a increment.
-        /// </summary>
-        /// <param name="subscriptionId">Required parameter: Subscription id.</param>
-        /// <param name="request">Required parameter: Request for creating a increment.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetIncrementResponse response from the API call.</returns>
-        public async Task<Models.GetIncrementResponse> CreateIncrementAsync(
-                string subscriptionId,
-                Models.CreateIncrementRequest request,
-                string idempotencyKey = null,
-                CancellationToken cancellationToken = default)
-        {
-            // the base uri for api requests.
-            string baseUri = this.Config.GetBaseUri();
-
-            // prepare query string for API call.
-            StringBuilder queryBuilder = new StringBuilder(baseUri);
-            queryBuilder.Append("/subscriptions/{subscription_id}/increments");
-
-            // process optional template parameters.
-            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
-            {
-                { "subscription_id", subscriptionId },
-            });
-
-            // append request with appropriate headers and parameters
-            var headers = new Dictionary<string, string>()
-            {
-                { "user-agent", this.UserAgent },
-                { "accept", "application/json" },
-                { "content-type", "application/json; charset=utf-8" },
-                { "idempotency-key", idempotencyKey },
-            };
-
-            // append body params.
-            var bodyText = ApiHelper.JsonSerialize(request);
-
-            // prepare the API call request to fetch the response.
-            HttpRequest httpRequest = this.GetClientInstance().PostBody(queryBuilder.ToString(), headers, bodyText);
-
-            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
-
-            // invoke request and get response.
-            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
-            HttpContext context = new HttpContext(httpRequest, response);
-
-            // handle errors defined at the API level.
-            this.ValidateResponse(response, context);
-
-            return ApiHelper.JsonDeserialize<Models.GetIncrementResponse>(response.Body);
-        }
-
-        /// <summary>
-        /// Creates a usage.
-        /// </summary>
-        /// <param name="subscriptionId">Required parameter: Subscription Id.</param>
-        /// <param name="itemId">Required parameter: Item id.</param>
-        /// <param name="body">Required parameter: Request for creating a usage.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <returns>Returns the Models.GetUsageResponse response from the API call.</returns>
-        public Models.GetUsageResponse CreateUsage(
-                string subscriptionId,
-                string itemId,
-                Models.CreateUsageRequest body,
-                string idempotencyKey = null)
-        {
-            Task<Models.GetUsageResponse> t = this.CreateUsageAsync(subscriptionId, itemId, body, idempotencyKey);
-            ApiHelper.RunTaskSynchronously(t);
-            return t.Result;
-        }
-
-        /// <summary>
-        /// Creates a usage.
-        /// </summary>
-        /// <param name="subscriptionId">Required parameter: Subscription Id.</param>
-        /// <param name="itemId">Required parameter: Item id.</param>
-        /// <param name="body">Required parameter: Request for creating a usage.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetUsageResponse response from the API call.</returns>
-        public async Task<Models.GetUsageResponse> CreateUsageAsync(
-                string subscriptionId,
-                string itemId,
-                Models.CreateUsageRequest body,
-                string idempotencyKey = null,
-                CancellationToken cancellationToken = default)
-        {
-            // the base uri for api requests.
-            string baseUri = this.Config.GetBaseUri();
-
-            // prepare query string for API call.
-            StringBuilder queryBuilder = new StringBuilder(baseUri);
-            queryBuilder.Append("/subscriptions/{subscription_id}/items/{item_id}/usages");
-
-            // process optional template parameters.
-            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
-            {
-                { "subscription_id", subscriptionId },
-                { "item_id", itemId },
-            });
-
-            // append request with appropriate headers and parameters
-            var headers = new Dictionary<string, string>()
-            {
-                { "user-agent", this.UserAgent },
-                { "accept", "application/json" },
-                { "content-type", "application/json; charset=utf-8" },
-                { "idempotency-key", idempotencyKey },
-            };
-
-            // append body params.
-            var bodyText = ApiHelper.JsonSerialize(body);
-
-            // prepare the API call request to fetch the response.
-            HttpRequest httpRequest = this.GetClientInstance().PostBody(queryBuilder.ToString(), headers, bodyText);
-
-            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
-
-            // invoke request and get response.
-            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
-            HttpContext context = new HttpContext(httpRequest, response);
-
-            // handle errors defined at the API level.
-            this.ValidateResponse(response, context);
-
-            return ApiHelper.JsonDeserialize<Models.GetUsageResponse>(response.Body);
         }
 
         /// <summary>
@@ -1272,77 +468,6 @@ namespace PagarmeApiSDK.Standard.Controllers
         }
 
         /// <summary>
-        /// UpdateSubscriptionAffiliationId EndPoint.
-        /// </summary>
-        /// <param name="subscriptionId">Required parameter: Example: .</param>
-        /// <param name="request">Required parameter: Request for updating a subscription affiliation id.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <returns>Returns the Models.GetSubscriptionResponse response from the API call.</returns>
-        public Models.GetSubscriptionResponse UpdateSubscriptionAffiliationId(
-                string subscriptionId,
-                Models.UpdateSubscriptionAffiliationIdRequest request,
-                string idempotencyKey = null)
-        {
-            Task<Models.GetSubscriptionResponse> t = this.UpdateSubscriptionAffiliationIdAsync(subscriptionId, request, idempotencyKey);
-            ApiHelper.RunTaskSynchronously(t);
-            return t.Result;
-        }
-
-        /// <summary>
-        /// UpdateSubscriptionAffiliationId EndPoint.
-        /// </summary>
-        /// <param name="subscriptionId">Required parameter: Example: .</param>
-        /// <param name="request">Required parameter: Request for updating a subscription affiliation id.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetSubscriptionResponse response from the API call.</returns>
-        public async Task<Models.GetSubscriptionResponse> UpdateSubscriptionAffiliationIdAsync(
-                string subscriptionId,
-                Models.UpdateSubscriptionAffiliationIdRequest request,
-                string idempotencyKey = null,
-                CancellationToken cancellationToken = default)
-        {
-            // the base uri for api requests.
-            string baseUri = this.Config.GetBaseUri();
-
-            // prepare query string for API call.
-            StringBuilder queryBuilder = new StringBuilder(baseUri);
-            queryBuilder.Append("/subscriptions/{subscription_id}/gateway-affiliation-id");
-
-            // process optional template parameters.
-            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
-            {
-                { "subscription_id", subscriptionId },
-            });
-
-            // append request with appropriate headers and parameters
-            var headers = new Dictionary<string, string>()
-            {
-                { "user-agent", this.UserAgent },
-                { "accept", "application/json" },
-                { "content-type", "application/json; charset=utf-8" },
-                { "idempotency-key", idempotencyKey },
-            };
-
-            // append body params.
-            var bodyText = ApiHelper.JsonSerialize(request);
-
-            // prepare the API call request to fetch the response.
-            HttpRequest httpRequest = this.GetClientInstance().PatchBody(queryBuilder.ToString(), headers, bodyText);
-
-            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
-
-            // invoke request and get response.
-            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
-            HttpContext context = new HttpContext(httpRequest, response);
-
-            // handle errors defined at the API level.
-            this.ValidateResponse(response, context);
-
-            return ApiHelper.JsonDeserialize<Models.GetSubscriptionResponse>(response.Body);
-        }
-
-        /// <summary>
         /// Updates the metadata from a subscription.
         /// </summary>
         /// <param name="subscriptionId">Required parameter: The subscription id.</param>
@@ -1482,34 +607,26 @@ namespace PagarmeApiSDK.Standard.Controllers
         }
 
         /// <summary>
-        /// GetSubscriptionCycles EndPoint.
+        /// Gets a subscription.
         /// </summary>
-        /// <param name="subscriptionId">Required parameter: Subscription Id.</param>
-        /// <param name="page">Required parameter: Page number.</param>
-        /// <param name="size">Required parameter: Page size.</param>
-        /// <returns>Returns the Models.ListCyclesResponse response from the API call.</returns>
-        public Models.ListCyclesResponse GetSubscriptionCycles(
-                string subscriptionId,
-                string page,
-                string size)
+        /// <param name="subscriptionId">Required parameter: Subscription id.</param>
+        /// <returns>Returns the Models.GetSubscriptionResponse response from the API call.</returns>
+        public Models.GetSubscriptionResponse GetSubscription(
+                string subscriptionId)
         {
-            Task<Models.ListCyclesResponse> t = this.GetSubscriptionCyclesAsync(subscriptionId, page, size);
+            Task<Models.GetSubscriptionResponse> t = this.GetSubscriptionAsync(subscriptionId);
             ApiHelper.RunTaskSynchronously(t);
             return t.Result;
         }
 
         /// <summary>
-        /// GetSubscriptionCycles EndPoint.
+        /// Gets a subscription.
         /// </summary>
-        /// <param name="subscriptionId">Required parameter: Subscription Id.</param>
-        /// <param name="page">Required parameter: Page number.</param>
-        /// <param name="size">Required parameter: Page size.</param>
+        /// <param name="subscriptionId">Required parameter: Subscription id.</param>
         /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.ListCyclesResponse response from the API call.</returns>
-        public async Task<Models.ListCyclesResponse> GetSubscriptionCyclesAsync(
+        /// <returns>Returns the Models.GetSubscriptionResponse response from the API call.</returns>
+        public async Task<Models.GetSubscriptionResponse> GetSubscriptionAsync(
                 string subscriptionId,
-                string page,
-                string size,
                 CancellationToken cancellationToken = default)
         {
             // the base uri for api requests.
@@ -1517,7 +634,234 @@ namespace PagarmeApiSDK.Standard.Controllers
 
             // prepare query string for API call.
             StringBuilder queryBuilder = new StringBuilder(baseUri);
-            queryBuilder.Append("/subscriptions/{subscription_id}/cycles");
+            queryBuilder.Append("/subscriptions/{subscription_id}");
+
+            // process optional template parameters.
+            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
+            {
+                { "subscription_id", subscriptionId },
+            });
+
+            // append request with appropriate headers and parameters
+            var headers = new Dictionary<string, string>()
+            {
+                { "user-agent", this.UserAgent },
+                { "accept", "application/json" },
+            };
+
+            // prepare the API call request to fetch the response.
+            HttpRequest httpRequest = this.GetClientInstance().Get(queryBuilder.ToString(), headers);
+
+            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
+
+            // invoke request and get response.
+            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+            HttpContext context = new HttpContext(httpRequest, response);
+
+            // handle errors defined at the API level.
+            this.ValidateResponse(response, context);
+
+            return ApiHelper.JsonDeserialize<Models.GetSubscriptionResponse>(response.Body);
+        }
+
+        /// <summary>
+        /// UpdateLatestPeriodEndAt EndPoint.
+        /// </summary>
+        /// <param name="subscriptionId">Required parameter: Example: .</param>
+        /// <param name="request">Required parameter: Request for updating the end date of the current signature cycle.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <returns>Returns the Models.GetSubscriptionResponse response from the API call.</returns>
+        public Models.GetSubscriptionResponse UpdateLatestPeriodEndAt(
+                string subscriptionId,
+                Models.UpdateCurrentCycleEndDateRequest request,
+                string idempotencyKey = null)
+        {
+            Task<Models.GetSubscriptionResponse> t = this.UpdateLatestPeriodEndAtAsync(subscriptionId, request, idempotencyKey);
+            ApiHelper.RunTaskSynchronously(t);
+            return t.Result;
+        }
+
+        /// <summary>
+        /// UpdateLatestPeriodEndAt EndPoint.
+        /// </summary>
+        /// <param name="subscriptionId">Required parameter: Example: .</param>
+        /// <param name="request">Required parameter: Request for updating the end date of the current signature cycle.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetSubscriptionResponse response from the API call.</returns>
+        public async Task<Models.GetSubscriptionResponse> UpdateLatestPeriodEndAtAsync(
+                string subscriptionId,
+                Models.UpdateCurrentCycleEndDateRequest request,
+                string idempotencyKey = null,
+                CancellationToken cancellationToken = default)
+        {
+            // the base uri for api requests.
+            string baseUri = this.Config.GetBaseUri();
+
+            // prepare query string for API call.
+            StringBuilder queryBuilder = new StringBuilder(baseUri);
+            queryBuilder.Append("/subscriptions/{subscription_id}/periods/latest/end-at");
+
+            // process optional template parameters.
+            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
+            {
+                { "subscription_id", subscriptionId },
+            });
+
+            // append request with appropriate headers and parameters
+            var headers = new Dictionary<string, string>()
+            {
+                { "user-agent", this.UserAgent },
+                { "accept", "application/json" },
+                { "content-type", "application/json; charset=utf-8" },
+                { "idempotency-key", idempotencyKey },
+            };
+
+            // append body params.
+            var bodyText = ApiHelper.JsonSerialize(request);
+
+            // prepare the API call request to fetch the response.
+            HttpRequest httpRequest = this.GetClientInstance().PatchBody(queryBuilder.ToString(), headers, bodyText);
+
+            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
+
+            // invoke request and get response.
+            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+            HttpContext context = new HttpContext(httpRequest, response);
+
+            // handle errors defined at the API level.
+            this.ValidateResponse(response, context);
+
+            return ApiHelper.JsonDeserialize<Models.GetSubscriptionResponse>(response.Body);
+        }
+
+        /// <summary>
+        /// UpdateCurrentCycleStatus EndPoint.
+        /// </summary>
+        /// <param name="subscriptionId">Required parameter: Subscription Id.</param>
+        /// <param name="request">Required parameter: Request for updating the end date of the subscription current status.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        public void UpdateCurrentCycleStatus(
+                string subscriptionId,
+                Models.UpdateCurrentCycleStatusRequest request,
+                string idempotencyKey = null)
+        {
+            Task t = this.UpdateCurrentCycleStatusAsync(subscriptionId, request, idempotencyKey);
+            ApiHelper.RunTaskSynchronously(t);
+        }
+
+        /// <summary>
+        /// UpdateCurrentCycleStatus EndPoint.
+        /// </summary>
+        /// <param name="subscriptionId">Required parameter: Subscription Id.</param>
+        /// <param name="request">Required parameter: Request for updating the end date of the subscription current status.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the void response from the API call.</returns>
+        public async Task UpdateCurrentCycleStatusAsync(
+                string subscriptionId,
+                Models.UpdateCurrentCycleStatusRequest request,
+                string idempotencyKey = null,
+                CancellationToken cancellationToken = default)
+        {
+            // the base uri for api requests.
+            string baseUri = this.Config.GetBaseUri();
+
+            // prepare query string for API call.
+            StringBuilder queryBuilder = new StringBuilder(baseUri);
+            queryBuilder.Append("/subscriptions/{subscription_id}/cycle-status");
+
+            // process optional template parameters.
+            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
+            {
+                { "subscription_id", subscriptionId },
+            });
+
+            // append request with appropriate headers and parameters
+            var headers = new Dictionary<string, string>()
+            {
+                { "user-agent", this.UserAgent },
+                { "content-type", "application/json; charset=utf-8" },
+                { "idempotency-key", idempotencyKey },
+            };
+
+            // append body params.
+            var bodyText = ApiHelper.JsonSerialize(request);
+
+            // prepare the API call request to fetch the response.
+            HttpRequest httpRequest = this.GetClientInstance().PatchBody(queryBuilder.ToString(), headers, bodyText);
+
+            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
+
+            // invoke request and get response.
+            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+            HttpContext context = new HttpContext(httpRequest, response);
+
+            // handle errors defined at the API level.
+            this.ValidateResponse(response, context);
+        }
+
+        /// <summary>
+        /// Get Subscription Items.
+        /// </summary>
+        /// <param name="subscriptionId">Required parameter: The subscription id.</param>
+        /// <param name="page">Optional parameter: Page number.</param>
+        /// <param name="size">Optional parameter: Page size.</param>
+        /// <param name="name">Optional parameter: The item name.</param>
+        /// <param name="code">Optional parameter: Identification code in the client system.</param>
+        /// <param name="status">Optional parameter: The item statis.</param>
+        /// <param name="description">Optional parameter: The item description.</param>
+        /// <param name="createdSince">Optional parameter: Filter for item's creation date start range.</param>
+        /// <param name="createdUntil">Optional parameter: Filter for item's creation date end range.</param>
+        /// <returns>Returns the Models.ListSubscriptionItemsResponse response from the API call.</returns>
+        public Models.ListSubscriptionItemsResponse GetSubscriptionItems(
+                string subscriptionId,
+                int? page = null,
+                int? size = null,
+                string name = null,
+                string code = null,
+                string status = null,
+                string description = null,
+                string createdSince = null,
+                string createdUntil = null)
+        {
+            Task<Models.ListSubscriptionItemsResponse> t = this.GetSubscriptionItemsAsync(subscriptionId, page, size, name, code, status, description, createdSince, createdUntil);
+            ApiHelper.RunTaskSynchronously(t);
+            return t.Result;
+        }
+
+        /// <summary>
+        /// Get Subscription Items.
+        /// </summary>
+        /// <param name="subscriptionId">Required parameter: The subscription id.</param>
+        /// <param name="page">Optional parameter: Page number.</param>
+        /// <param name="size">Optional parameter: Page size.</param>
+        /// <param name="name">Optional parameter: The item name.</param>
+        /// <param name="code">Optional parameter: Identification code in the client system.</param>
+        /// <param name="status">Optional parameter: The item statis.</param>
+        /// <param name="description">Optional parameter: The item description.</param>
+        /// <param name="createdSince">Optional parameter: Filter for item's creation date start range.</param>
+        /// <param name="createdUntil">Optional parameter: Filter for item's creation date end range.</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.ListSubscriptionItemsResponse response from the API call.</returns>
+        public async Task<Models.ListSubscriptionItemsResponse> GetSubscriptionItemsAsync(
+                string subscriptionId,
+                int? page = null,
+                int? size = null,
+                string name = null,
+                string code = null,
+                string status = null,
+                string description = null,
+                string createdSince = null,
+                string createdUntil = null,
+                CancellationToken cancellationToken = default)
+        {
+            // the base uri for api requests.
+            string baseUri = this.Config.GetBaseUri();
+
+            // prepare query string for API call.
+            StringBuilder queryBuilder = new StringBuilder(baseUri);
+            queryBuilder.Append("/subscriptions/{subscription_id}/items");
 
             // process optional template parameters.
             ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
@@ -1530,6 +874,12 @@ namespace PagarmeApiSDK.Standard.Controllers
             {
                 { "page", page },
                 { "size", size },
+                { "name", name },
+                { "code", code },
+                { "status", status },
+                { "description", description },
+                { "created_since", createdSince },
+                { "created_until", createdUntil },
             };
 
             // append request with appropriate headers and parameters
@@ -1551,7 +901,141 @@ namespace PagarmeApiSDK.Standard.Controllers
             // handle errors defined at the API level.
             this.ValidateResponse(response, context);
 
-            return ApiHelper.JsonDeserialize<Models.ListCyclesResponse>(response.Body);
+            return ApiHelper.JsonDeserialize<Models.ListSubscriptionItemsResponse>(response.Body);
+        }
+
+        /// <summary>
+        /// Get Subscription Item.
+        /// </summary>
+        /// <param name="subscriptionId">Required parameter: Subscription Id.</param>
+        /// <param name="itemId">Required parameter: Item id.</param>
+        /// <returns>Returns the Models.GetSubscriptionItemResponse response from the API call.</returns>
+        public Models.GetSubscriptionItemResponse GetSubscriptionItem(
+                string subscriptionId,
+                string itemId)
+        {
+            Task<Models.GetSubscriptionItemResponse> t = this.GetSubscriptionItemAsync(subscriptionId, itemId);
+            ApiHelper.RunTaskSynchronously(t);
+            return t.Result;
+        }
+
+        /// <summary>
+        /// Get Subscription Item.
+        /// </summary>
+        /// <param name="subscriptionId">Required parameter: Subscription Id.</param>
+        /// <param name="itemId">Required parameter: Item id.</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetSubscriptionItemResponse response from the API call.</returns>
+        public async Task<Models.GetSubscriptionItemResponse> GetSubscriptionItemAsync(
+                string subscriptionId,
+                string itemId,
+                CancellationToken cancellationToken = default)
+        {
+            // the base uri for api requests.
+            string baseUri = this.Config.GetBaseUri();
+
+            // prepare query string for API call.
+            StringBuilder queryBuilder = new StringBuilder(baseUri);
+            queryBuilder.Append("/subscriptions/{subscription_id}/items/{item_id}");
+
+            // process optional template parameters.
+            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
+            {
+                { "subscription_id", subscriptionId },
+                { "item_id", itemId },
+            });
+
+            // append request with appropriate headers and parameters
+            var headers = new Dictionary<string, string>()
+            {
+                { "user-agent", this.UserAgent },
+                { "accept", "application/json" },
+            };
+
+            // prepare the API call request to fetch the response.
+            HttpRequest httpRequest = this.GetClientInstance().Get(queryBuilder.ToString(), headers);
+
+            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
+
+            // invoke request and get response.
+            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+            HttpContext context = new HttpContext(httpRequest, response);
+
+            // handle errors defined at the API level.
+            this.ValidateResponse(response, context);
+
+            return ApiHelper.JsonDeserialize<Models.GetSubscriptionItemResponse>(response.Body);
+        }
+
+        /// <summary>
+        /// UpdateSubscriptionAffiliationId EndPoint.
+        /// </summary>
+        /// <param name="subscriptionId">Required parameter: Example: .</param>
+        /// <param name="request">Required parameter: Request for updating a subscription affiliation id.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <returns>Returns the Models.GetSubscriptionResponse response from the API call.</returns>
+        public Models.GetSubscriptionResponse UpdateSubscriptionAffiliationId(
+                string subscriptionId,
+                Models.UpdateSubscriptionAffiliationIdRequest request,
+                string idempotencyKey = null)
+        {
+            Task<Models.GetSubscriptionResponse> t = this.UpdateSubscriptionAffiliationIdAsync(subscriptionId, request, idempotencyKey);
+            ApiHelper.RunTaskSynchronously(t);
+            return t.Result;
+        }
+
+        /// <summary>
+        /// UpdateSubscriptionAffiliationId EndPoint.
+        /// </summary>
+        /// <param name="subscriptionId">Required parameter: Example: .</param>
+        /// <param name="request">Required parameter: Request for updating a subscription affiliation id.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetSubscriptionResponse response from the API call.</returns>
+        public async Task<Models.GetSubscriptionResponse> UpdateSubscriptionAffiliationIdAsync(
+                string subscriptionId,
+                Models.UpdateSubscriptionAffiliationIdRequest request,
+                string idempotencyKey = null,
+                CancellationToken cancellationToken = default)
+        {
+            // the base uri for api requests.
+            string baseUri = this.Config.GetBaseUri();
+
+            // prepare query string for API call.
+            StringBuilder queryBuilder = new StringBuilder(baseUri);
+            queryBuilder.Append("/subscriptions/{subscription_id}/gateway-affiliation-id");
+
+            // process optional template parameters.
+            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
+            {
+                { "subscription_id", subscriptionId },
+            });
+
+            // append request with appropriate headers and parameters
+            var headers = new Dictionary<string, string>()
+            {
+                { "user-agent", this.UserAgent },
+                { "accept", "application/json" },
+                { "content-type", "application/json; charset=utf-8" },
+                { "idempotency-key", idempotencyKey },
+            };
+
+            // append body params.
+            var bodyText = ApiHelper.JsonSerialize(request);
+
+            // prepare the API call request to fetch the response.
+            HttpRequest httpRequest = this.GetClientInstance().PatchBody(queryBuilder.ToString(), headers, bodyText);
+
+            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
+
+            // invoke request and get response.
+            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+            HttpContext context = new HttpContext(httpRequest, response);
+
+            // handle errors defined at the API level.
+            this.ValidateResponse(response, context);
+
+            return ApiHelper.JsonDeserialize<Models.GetSubscriptionResponse>(response.Body);
         }
 
         /// <summary>
@@ -1628,33 +1112,37 @@ namespace PagarmeApiSDK.Standard.Controllers
         }
 
         /// <summary>
-        /// Updates the billing date from a subscription.
+        /// Updates a subscription item.
         /// </summary>
-        /// <param name="subscriptionId">Required parameter: The subscription id.</param>
-        /// <param name="request">Required parameter: Request for updating the subscription billing date.</param>
+        /// <param name="subscriptionId">Required parameter: Subscription Id.</param>
+        /// <param name="itemId">Required parameter: Item id.</param>
+        /// <param name="body">Required parameter: Request for updating a subscription item.</param>
         /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <returns>Returns the Models.GetSubscriptionResponse response from the API call.</returns>
-        public Models.GetSubscriptionResponse UpdateSubscriptionBillingDate(
+        /// <returns>Returns the Models.GetSubscriptionItemResponse response from the API call.</returns>
+        public Models.GetSubscriptionItemResponse UpdateSubscriptionItem(
                 string subscriptionId,
-                Models.UpdateSubscriptionBillingDateRequest request,
+                string itemId,
+                Models.UpdateSubscriptionItemRequest body,
                 string idempotencyKey = null)
         {
-            Task<Models.GetSubscriptionResponse> t = this.UpdateSubscriptionBillingDateAsync(subscriptionId, request, idempotencyKey);
+            Task<Models.GetSubscriptionItemResponse> t = this.UpdateSubscriptionItemAsync(subscriptionId, itemId, body, idempotencyKey);
             ApiHelper.RunTaskSynchronously(t);
             return t.Result;
         }
 
         /// <summary>
-        /// Updates the billing date from a subscription.
+        /// Updates a subscription item.
         /// </summary>
-        /// <param name="subscriptionId">Required parameter: The subscription id.</param>
-        /// <param name="request">Required parameter: Request for updating the subscription billing date.</param>
+        /// <param name="subscriptionId">Required parameter: Subscription Id.</param>
+        /// <param name="itemId">Required parameter: Item id.</param>
+        /// <param name="body">Required parameter: Request for updating a subscription item.</param>
         /// <param name="idempotencyKey">Optional parameter: Example: .</param>
         /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetSubscriptionResponse response from the API call.</returns>
-        public async Task<Models.GetSubscriptionResponse> UpdateSubscriptionBillingDateAsync(
+        /// <returns>Returns the Models.GetSubscriptionItemResponse response from the API call.</returns>
+        public async Task<Models.GetSubscriptionItemResponse> UpdateSubscriptionItemAsync(
                 string subscriptionId,
-                Models.UpdateSubscriptionBillingDateRequest request,
+                string itemId,
+                Models.UpdateSubscriptionItemRequest body,
                 string idempotencyKey = null,
                 CancellationToken cancellationToken = default)
         {
@@ -1663,7 +1151,248 @@ namespace PagarmeApiSDK.Standard.Controllers
 
             // prepare query string for API call.
             StringBuilder queryBuilder = new StringBuilder(baseUri);
-            queryBuilder.Append("/subscriptions/{subscription_id}/billing-date");
+            queryBuilder.Append("/subscriptions/{subscription_id}/items/{item_id}");
+
+            // process optional template parameters.
+            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
+            {
+                { "subscription_id", subscriptionId },
+                { "item_id", itemId },
+            });
+
+            // append request with appropriate headers and parameters
+            var headers = new Dictionary<string, string>()
+            {
+                { "user-agent", this.UserAgent },
+                { "accept", "application/json" },
+                { "content-type", "application/json; charset=utf-8" },
+                { "idempotency-key", idempotencyKey },
+            };
+
+            // append body params.
+            var bodyText = ApiHelper.JsonSerialize(body);
+
+            // prepare the API call request to fetch the response.
+            HttpRequest httpRequest = this.GetClientInstance().PutBody(queryBuilder.ToString(), headers, bodyText);
+
+            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
+
+            // invoke request and get response.
+            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+            HttpContext context = new HttpContext(httpRequest, response);
+
+            // handle errors defined at the API level.
+            this.ValidateResponse(response, context);
+
+            return ApiHelper.JsonDeserialize<Models.GetSubscriptionItemResponse>(response.Body);
+        }
+
+        /// <summary>
+        /// Creates a new Subscription item.
+        /// </summary>
+        /// <param name="subscriptionId">Required parameter: Subscription id.</param>
+        /// <param name="request">Required parameter: Request for creating a subscription item.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <returns>Returns the Models.GetSubscriptionItemResponse response from the API call.</returns>
+        public Models.GetSubscriptionItemResponse CreateSubscriptionItem(
+                string subscriptionId,
+                Models.CreateSubscriptionItemRequest request,
+                string idempotencyKey = null)
+        {
+            Task<Models.GetSubscriptionItemResponse> t = this.CreateSubscriptionItemAsync(subscriptionId, request, idempotencyKey);
+            ApiHelper.RunTaskSynchronously(t);
+            return t.Result;
+        }
+
+        /// <summary>
+        /// Creates a new Subscription item.
+        /// </summary>
+        /// <param name="subscriptionId">Required parameter: Subscription id.</param>
+        /// <param name="request">Required parameter: Request for creating a subscription item.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetSubscriptionItemResponse response from the API call.</returns>
+        public async Task<Models.GetSubscriptionItemResponse> CreateSubscriptionItemAsync(
+                string subscriptionId,
+                Models.CreateSubscriptionItemRequest request,
+                string idempotencyKey = null,
+                CancellationToken cancellationToken = default)
+        {
+            // the base uri for api requests.
+            string baseUri = this.Config.GetBaseUri();
+
+            // prepare query string for API call.
+            StringBuilder queryBuilder = new StringBuilder(baseUri);
+            queryBuilder.Append("/subscriptions/{subscription_id}/items");
+
+            // process optional template parameters.
+            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
+            {
+                { "subscription_id", subscriptionId },
+            });
+
+            // append request with appropriate headers and parameters
+            var headers = new Dictionary<string, string>()
+            {
+                { "user-agent", this.UserAgent },
+                { "accept", "application/json" },
+                { "content-type", "application/json; charset=utf-8" },
+                { "idempotency-key", idempotencyKey },
+            };
+
+            // append body params.
+            var bodyText = ApiHelper.JsonSerialize(request);
+
+            // prepare the API call request to fetch the response.
+            HttpRequest httpRequest = this.GetClientInstance().PostBody(queryBuilder.ToString(), headers, bodyText);
+
+            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
+
+            // invoke request and get response.
+            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+            HttpContext context = new HttpContext(httpRequest, response);
+
+            // handle errors defined at the API level.
+            this.ValidateResponse(response, context);
+
+            return ApiHelper.JsonDeserialize<Models.GetSubscriptionItemResponse>(response.Body);
+        }
+
+        /// <summary>
+        /// Lists all usages from a subscription item.
+        /// </summary>
+        /// <param name="subscriptionId">Required parameter: The subscription id.</param>
+        /// <param name="itemId">Required parameter: The subscription item id.</param>
+        /// <param name="page">Optional parameter: Page number.</param>
+        /// <param name="size">Optional parameter: Page size.</param>
+        /// <param name="code">Optional parameter: Identification code in the client system.</param>
+        /// <param name="mGroup">Optional parameter: Identification group in the client system.</param>
+        /// <param name="usedSince">Optional parameter: Example: .</param>
+        /// <param name="usedUntil">Optional parameter: Example: .</param>
+        /// <returns>Returns the Models.ListUsagesResponse response from the API call.</returns>
+        public Models.ListUsagesResponse GetUsages(
+                string subscriptionId,
+                string itemId,
+                int? page = null,
+                int? size = null,
+                string code = null,
+                string mGroup = null,
+                DateTime? usedSince = null,
+                DateTime? usedUntil = null)
+        {
+            Task<Models.ListUsagesResponse> t = this.GetUsagesAsync(subscriptionId, itemId, page, size, code, mGroup, usedSince, usedUntil);
+            ApiHelper.RunTaskSynchronously(t);
+            return t.Result;
+        }
+
+        /// <summary>
+        /// Lists all usages from a subscription item.
+        /// </summary>
+        /// <param name="subscriptionId">Required parameter: The subscription id.</param>
+        /// <param name="itemId">Required parameter: The subscription item id.</param>
+        /// <param name="page">Optional parameter: Page number.</param>
+        /// <param name="size">Optional parameter: Page size.</param>
+        /// <param name="code">Optional parameter: Identification code in the client system.</param>
+        /// <param name="mGroup">Optional parameter: Identification group in the client system.</param>
+        /// <param name="usedSince">Optional parameter: Example: .</param>
+        /// <param name="usedUntil">Optional parameter: Example: .</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.ListUsagesResponse response from the API call.</returns>
+        public async Task<Models.ListUsagesResponse> GetUsagesAsync(
+                string subscriptionId,
+                string itemId,
+                int? page = null,
+                int? size = null,
+                string code = null,
+                string mGroup = null,
+                DateTime? usedSince = null,
+                DateTime? usedUntil = null,
+                CancellationToken cancellationToken = default)
+        {
+            // the base uri for api requests.
+            string baseUri = this.Config.GetBaseUri();
+
+            // prepare query string for API call.
+            StringBuilder queryBuilder = new StringBuilder(baseUri);
+            queryBuilder.Append("/subscriptions/{subscription_id}/items/{item_id}/usages");
+
+            // process optional template parameters.
+            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
+            {
+                { "subscription_id", subscriptionId },
+                { "item_id", itemId },
+            });
+
+            // prepare specfied query parameters.
+            var queryParams = new Dictionary<string, object>()
+            {
+                { "page", page },
+                { "size", size },
+                { "code", code },
+                { "group", mGroup },
+                { "used_since", usedSince.HasValue ? usedSince.Value.ToString("yyyy'-'MM'-'dd'T'HH':'mm':'ss.FFFFFFFK") : null },
+                { "used_until", usedUntil.HasValue ? usedUntil.Value.ToString("yyyy'-'MM'-'dd'T'HH':'mm':'ss.FFFFFFFK") : null },
+            };
+
+            // append request with appropriate headers and parameters
+            var headers = new Dictionary<string, string>()
+            {
+                { "user-agent", this.UserAgent },
+                { "accept", "application/json" },
+            };
+
+            // prepare the API call request to fetch the response.
+            HttpRequest httpRequest = this.GetClientInstance().Get(queryBuilder.ToString(), headers, queryParameters: queryParams);
+
+            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
+
+            // invoke request and get response.
+            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+            HttpContext context = new HttpContext(httpRequest, response);
+
+            // handle errors defined at the API level.
+            this.ValidateResponse(response, context);
+
+            return ApiHelper.JsonDeserialize<Models.ListUsagesResponse>(response.Body);
+        }
+
+        /// <summary>
+        /// Atualização do valor mínimo da assinatura.
+        /// </summary>
+        /// <param name="subscriptionId">Required parameter: Subscription Id.</param>
+        /// <param name="request">Required parameter: Request da requisição com o valor mínimo que será configurado.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <returns>Returns the Models.GetSubscriptionResponse response from the API call.</returns>
+        public Models.GetSubscriptionResponse UpdateSubscriptionMiniumPrice(
+                string subscriptionId,
+                Models.UpdateSubscriptionMinimumPriceRequest request,
+                string idempotencyKey = null)
+        {
+            Task<Models.GetSubscriptionResponse> t = this.UpdateSubscriptionMiniumPriceAsync(subscriptionId, request, idempotencyKey);
+            ApiHelper.RunTaskSynchronously(t);
+            return t.Result;
+        }
+
+        /// <summary>
+        /// Atualização do valor mínimo da assinatura.
+        /// </summary>
+        /// <param name="subscriptionId">Required parameter: Subscription Id.</param>
+        /// <param name="request">Required parameter: Request da requisição com o valor mínimo que será configurado.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetSubscriptionResponse response from the API call.</returns>
+        public async Task<Models.GetSubscriptionResponse> UpdateSubscriptionMiniumPriceAsync(
+                string subscriptionId,
+                Models.UpdateSubscriptionMinimumPriceRequest request,
+                string idempotencyKey = null,
+                CancellationToken cancellationToken = default)
+        {
+            // the base uri for api requests.
+            string baseUri = this.Config.GetBaseUri();
+
+            // prepare query string for API call.
+            StringBuilder queryBuilder = new StringBuilder(baseUri);
+            queryBuilder.Append("/subscriptions/{subscription_id}/minimum_price");
 
             // process optional template parameters.
             ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
@@ -1685,6 +1414,208 @@ namespace PagarmeApiSDK.Standard.Controllers
 
             // prepare the API call request to fetch the response.
             HttpRequest httpRequest = this.GetClientInstance().PatchBody(queryBuilder.ToString(), headers, bodyText);
+
+            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
+
+            // invoke request and get response.
+            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+            HttpContext context = new HttpContext(httpRequest, response);
+
+            // handle errors defined at the API level.
+            this.ValidateResponse(response, context);
+
+            return ApiHelper.JsonDeserialize<Models.GetSubscriptionResponse>(response.Body);
+        }
+
+        /// <summary>
+        /// GetSubscriptionCycleById EndPoint.
+        /// </summary>
+        /// <param name="subscriptionId">Required parameter: The subscription id.</param>
+        /// <param name="cycleId">Required parameter: Example: .</param>
+        /// <returns>Returns the Models.GetPeriodResponse response from the API call.</returns>
+        public Models.GetPeriodResponse GetSubscriptionCycleById(
+                string subscriptionId,
+                string cycleId)
+        {
+            Task<Models.GetPeriodResponse> t = this.GetSubscriptionCycleByIdAsync(subscriptionId, cycleId);
+            ApiHelper.RunTaskSynchronously(t);
+            return t.Result;
+        }
+
+        /// <summary>
+        /// GetSubscriptionCycleById EndPoint.
+        /// </summary>
+        /// <param name="subscriptionId">Required parameter: The subscription id.</param>
+        /// <param name="cycleId">Required parameter: Example: .</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetPeriodResponse response from the API call.</returns>
+        public async Task<Models.GetPeriodResponse> GetSubscriptionCycleByIdAsync(
+                string subscriptionId,
+                string cycleId,
+                CancellationToken cancellationToken = default)
+        {
+            // the base uri for api requests.
+            string baseUri = this.Config.GetBaseUri();
+
+            // prepare query string for API call.
+            StringBuilder queryBuilder = new StringBuilder(baseUri);
+            queryBuilder.Append("/subscriptions/{subscription_id}/cycles/{cycleId}");
+
+            // process optional template parameters.
+            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
+            {
+                { "subscription_id", subscriptionId },
+                { "cycleId", cycleId },
+            });
+
+            // append request with appropriate headers and parameters
+            var headers = new Dictionary<string, string>()
+            {
+                { "user-agent", this.UserAgent },
+                { "accept", "application/json" },
+            };
+
+            // prepare the API call request to fetch the response.
+            HttpRequest httpRequest = this.GetClientInstance().Get(queryBuilder.ToString(), headers);
+
+            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
+
+            // invoke request and get response.
+            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+            HttpContext context = new HttpContext(httpRequest, response);
+
+            // handle errors defined at the API level.
+            this.ValidateResponse(response, context);
+
+            return ApiHelper.JsonDeserialize<Models.GetPeriodResponse>(response.Body);
+        }
+
+        /// <summary>
+        /// Create Usage.
+        /// </summary>
+        /// <param name="subscriptionId">Required parameter: Subscription id.</param>
+        /// <param name="itemId">Required parameter: Item id.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <returns>Returns the Models.GetUsageResponse response from the API call.</returns>
+        public Models.GetUsageResponse CreateAnUsage(
+                string subscriptionId,
+                string itemId,
+                string idempotencyKey = null)
+        {
+            Task<Models.GetUsageResponse> t = this.CreateAnUsageAsync(subscriptionId, itemId, idempotencyKey);
+            ApiHelper.RunTaskSynchronously(t);
+            return t.Result;
+        }
+
+        /// <summary>
+        /// Create Usage.
+        /// </summary>
+        /// <param name="subscriptionId">Required parameter: Subscription id.</param>
+        /// <param name="itemId">Required parameter: Item id.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetUsageResponse response from the API call.</returns>
+        public async Task<Models.GetUsageResponse> CreateAnUsageAsync(
+                string subscriptionId,
+                string itemId,
+                string idempotencyKey = null,
+                CancellationToken cancellationToken = default)
+        {
+            // the base uri for api requests.
+            string baseUri = this.Config.GetBaseUri();
+
+            // prepare query string for API call.
+            StringBuilder queryBuilder = new StringBuilder(baseUri);
+            queryBuilder.Append("/subscriptions/{subscription_id}/items/{item_id}/usages");
+
+            // process optional template parameters.
+            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
+            {
+                { "subscription_id", subscriptionId },
+                { "item_id", itemId },
+            });
+
+            // append request with appropriate headers and parameters
+            var headers = new Dictionary<string, string>()
+            {
+                { "user-agent", this.UserAgent },
+                { "accept", "application/json" },
+                { "idempotency-key", idempotencyKey },
+            };
+
+            // prepare the API call request to fetch the response.
+            HttpRequest httpRequest = this.GetClientInstance().Post(queryBuilder.ToString(), headers, null);
+
+            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
+
+            // invoke request and get response.
+            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+            HttpContext context = new HttpContext(httpRequest, response);
+
+            // handle errors defined at the API level.
+            this.ValidateResponse(response, context);
+
+            return ApiHelper.JsonDeserialize<Models.GetUsageResponse>(response.Body);
+        }
+
+        /// <summary>
+        /// Cancels a subscription.
+        /// </summary>
+        /// <param name="subscriptionId">Required parameter: Subscription id.</param>
+        /// <param name="request">Optional parameter: Request for cancelling a subscription.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <returns>Returns the Models.GetSubscriptionResponse response from the API call.</returns>
+        public Models.GetSubscriptionResponse CancelSubscription(
+                string subscriptionId,
+                Models.CreateCancelSubscriptionRequest request = null,
+                string idempotencyKey = null)
+        {
+            Task<Models.GetSubscriptionResponse> t = this.CancelSubscriptionAsync(subscriptionId, request, idempotencyKey);
+            ApiHelper.RunTaskSynchronously(t);
+            return t.Result;
+        }
+
+        /// <summary>
+        /// Cancels a subscription.
+        /// </summary>
+        /// <param name="subscriptionId">Required parameter: Subscription id.</param>
+        /// <param name="request">Optional parameter: Request for cancelling a subscription.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetSubscriptionResponse response from the API call.</returns>
+        public async Task<Models.GetSubscriptionResponse> CancelSubscriptionAsync(
+                string subscriptionId,
+                Models.CreateCancelSubscriptionRequest request = null,
+                string idempotencyKey = null,
+                CancellationToken cancellationToken = default)
+        {
+            // the base uri for api requests.
+            string baseUri = this.Config.GetBaseUri();
+
+            // prepare query string for API call.
+            StringBuilder queryBuilder = new StringBuilder(baseUri);
+            queryBuilder.Append("/subscriptions/{subscription_id}");
+
+            // process optional template parameters.
+            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
+            {
+                { "subscription_id", subscriptionId },
+            });
+
+            // append request with appropriate headers and parameters
+            var headers = new Dictionary<string, string>()
+            {
+                { "user-agent", this.UserAgent },
+                { "accept", "application/json" },
+                { "content-type", "application/json; charset=utf-8" },
+                { "idempotency-key", idempotencyKey },
+            };
+
+            // append body params.
+            var bodyText = ApiHelper.JsonSerialize(request);
+
+            // prepare the API call request to fetch the response.
+            HttpRequest httpRequest = this.GetClientInstance().DeleteBody(queryBuilder.ToString(), headers, bodyText);
 
             httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
 
@@ -1911,6 +1842,583 @@ namespace PagarmeApiSDK.Standard.Controllers
         }
 
         /// <summary>
+        /// Updates the credit card from a subscription.
+        /// </summary>
+        /// <param name="subscriptionId">Required parameter: Subscription id.</param>
+        /// <param name="request">Required parameter: Request for updating a card.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <returns>Returns the Models.GetSubscriptionResponse response from the API call.</returns>
+        public Models.GetSubscriptionResponse UpdateSubscriptionCard(
+                string subscriptionId,
+                Models.UpdateSubscriptionCardRequest request,
+                string idempotencyKey = null)
+        {
+            Task<Models.GetSubscriptionResponse> t = this.UpdateSubscriptionCardAsync(subscriptionId, request, idempotencyKey);
+            ApiHelper.RunTaskSynchronously(t);
+            return t.Result;
+        }
+
+        /// <summary>
+        /// Updates the credit card from a subscription.
+        /// </summary>
+        /// <param name="subscriptionId">Required parameter: Subscription id.</param>
+        /// <param name="request">Required parameter: Request for updating a card.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetSubscriptionResponse response from the API call.</returns>
+        public async Task<Models.GetSubscriptionResponse> UpdateSubscriptionCardAsync(
+                string subscriptionId,
+                Models.UpdateSubscriptionCardRequest request,
+                string idempotencyKey = null,
+                CancellationToken cancellationToken = default)
+        {
+            // the base uri for api requests.
+            string baseUri = this.Config.GetBaseUri();
+
+            // prepare query string for API call.
+            StringBuilder queryBuilder = new StringBuilder(baseUri);
+            queryBuilder.Append("/subscriptions/{subscription_id}/card");
+
+            // process optional template parameters.
+            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
+            {
+                { "subscription_id", subscriptionId },
+            });
+
+            // append request with appropriate headers and parameters
+            var headers = new Dictionary<string, string>()
+            {
+                { "user-agent", this.UserAgent },
+                { "accept", "application/json" },
+                { "content-type", "application/json; charset=utf-8" },
+                { "idempotency-key", idempotencyKey },
+            };
+
+            // append body params.
+            var bodyText = ApiHelper.JsonSerialize(request);
+
+            // prepare the API call request to fetch the response.
+            HttpRequest httpRequest = this.GetClientInstance().PatchBody(queryBuilder.ToString(), headers, bodyText);
+
+            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
+
+            // invoke request and get response.
+            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+            HttpContext context = new HttpContext(httpRequest, response);
+
+            // handle errors defined at the API level.
+            this.ValidateResponse(response, context);
+
+            return ApiHelper.JsonDeserialize<Models.GetSubscriptionResponse>(response.Body);
+        }
+
+        /// <summary>
+        /// Deletes a usage.
+        /// </summary>
+        /// <param name="subscriptionId">Required parameter: The subscription id.</param>
+        /// <param name="itemId">Required parameter: The subscription item id.</param>
+        /// <param name="usageId">Required parameter: The usage id.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <returns>Returns the Models.GetUsageResponse response from the API call.</returns>
+        public Models.GetUsageResponse DeleteUsage(
+                string subscriptionId,
+                string itemId,
+                string usageId,
+                string idempotencyKey = null)
+        {
+            Task<Models.GetUsageResponse> t = this.DeleteUsageAsync(subscriptionId, itemId, usageId, idempotencyKey);
+            ApiHelper.RunTaskSynchronously(t);
+            return t.Result;
+        }
+
+        /// <summary>
+        /// Deletes a usage.
+        /// </summary>
+        /// <param name="subscriptionId">Required parameter: The subscription id.</param>
+        /// <param name="itemId">Required parameter: The subscription item id.</param>
+        /// <param name="usageId">Required parameter: The usage id.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetUsageResponse response from the API call.</returns>
+        public async Task<Models.GetUsageResponse> DeleteUsageAsync(
+                string subscriptionId,
+                string itemId,
+                string usageId,
+                string idempotencyKey = null,
+                CancellationToken cancellationToken = default)
+        {
+            // the base uri for api requests.
+            string baseUri = this.Config.GetBaseUri();
+
+            // prepare query string for API call.
+            StringBuilder queryBuilder = new StringBuilder(baseUri);
+            queryBuilder.Append("/subscriptions/{subscription_id}/items/{item_id}/usages/{usage_id}");
+
+            // process optional template parameters.
+            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
+            {
+                { "subscription_id", subscriptionId },
+                { "item_id", itemId },
+                { "usage_id", usageId },
+            });
+
+            // append request with appropriate headers and parameters
+            var headers = new Dictionary<string, string>()
+            {
+                { "user-agent", this.UserAgent },
+                { "accept", "application/json" },
+                { "idempotency-key", idempotencyKey },
+            };
+
+            // prepare the API call request to fetch the response.
+            HttpRequest httpRequest = this.GetClientInstance().Delete(queryBuilder.ToString(), headers, null);
+
+            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
+
+            // invoke request and get response.
+            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+            HttpContext context = new HttpContext(httpRequest, response);
+
+            // handle errors defined at the API level.
+            this.ValidateResponse(response, context);
+
+            return ApiHelper.JsonDeserialize<Models.GetUsageResponse>(response.Body);
+        }
+
+        /// <summary>
+        /// Creates a discount.
+        /// </summary>
+        /// <param name="subscriptionId">Required parameter: Subscription id.</param>
+        /// <param name="request">Required parameter: Request for creating a discount.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <returns>Returns the Models.GetDiscountResponse response from the API call.</returns>
+        public Models.GetDiscountResponse CreateDiscount(
+                string subscriptionId,
+                Models.CreateDiscountRequest request,
+                string idempotencyKey = null)
+        {
+            Task<Models.GetDiscountResponse> t = this.CreateDiscountAsync(subscriptionId, request, idempotencyKey);
+            ApiHelper.RunTaskSynchronously(t);
+            return t.Result;
+        }
+
+        /// <summary>
+        /// Creates a discount.
+        /// </summary>
+        /// <param name="subscriptionId">Required parameter: Subscription id.</param>
+        /// <param name="request">Required parameter: Request for creating a discount.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetDiscountResponse response from the API call.</returns>
+        public async Task<Models.GetDiscountResponse> CreateDiscountAsync(
+                string subscriptionId,
+                Models.CreateDiscountRequest request,
+                string idempotencyKey = null,
+                CancellationToken cancellationToken = default)
+        {
+            // the base uri for api requests.
+            string baseUri = this.Config.GetBaseUri();
+
+            // prepare query string for API call.
+            StringBuilder queryBuilder = new StringBuilder(baseUri);
+            queryBuilder.Append("/subscriptions/{subscription_id}/discounts");
+
+            // process optional template parameters.
+            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
+            {
+                { "subscription_id", subscriptionId },
+            });
+
+            // append request with appropriate headers and parameters
+            var headers = new Dictionary<string, string>()
+            {
+                { "user-agent", this.UserAgent },
+                { "accept", "application/json" },
+                { "content-type", "application/json; charset=utf-8" },
+                { "idempotency-key", idempotencyKey },
+            };
+
+            // append body params.
+            var bodyText = ApiHelper.JsonSerialize(request);
+
+            // prepare the API call request to fetch the response.
+            HttpRequest httpRequest = this.GetClientInstance().PostBody(queryBuilder.ToString(), headers, bodyText);
+
+            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
+
+            // invoke request and get response.
+            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+            HttpContext context = new HttpContext(httpRequest, response);
+
+            // handle errors defined at the API level.
+            this.ValidateResponse(response, context);
+
+            return ApiHelper.JsonDeserialize<Models.GetDiscountResponse>(response.Body);
+        }
+
+        /// <summary>
+        /// Updates the payment method from a subscription.
+        /// </summary>
+        /// <param name="subscriptionId">Required parameter: Subscription id.</param>
+        /// <param name="request">Required parameter: Request for updating the paymentmethod from a subscription.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <returns>Returns the Models.GetSubscriptionResponse response from the API call.</returns>
+        public Models.GetSubscriptionResponse UpdateSubscriptionPaymentMethod(
+                string subscriptionId,
+                Models.UpdateSubscriptionPaymentMethodRequest request,
+                string idempotencyKey = null)
+        {
+            Task<Models.GetSubscriptionResponse> t = this.UpdateSubscriptionPaymentMethodAsync(subscriptionId, request, idempotencyKey);
+            ApiHelper.RunTaskSynchronously(t);
+            return t.Result;
+        }
+
+        /// <summary>
+        /// Updates the payment method from a subscription.
+        /// </summary>
+        /// <param name="subscriptionId">Required parameter: Subscription id.</param>
+        /// <param name="request">Required parameter: Request for updating the paymentmethod from a subscription.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetSubscriptionResponse response from the API call.</returns>
+        public async Task<Models.GetSubscriptionResponse> UpdateSubscriptionPaymentMethodAsync(
+                string subscriptionId,
+                Models.UpdateSubscriptionPaymentMethodRequest request,
+                string idempotencyKey = null,
+                CancellationToken cancellationToken = default)
+        {
+            // the base uri for api requests.
+            string baseUri = this.Config.GetBaseUri();
+
+            // prepare query string for API call.
+            StringBuilder queryBuilder = new StringBuilder(baseUri);
+            queryBuilder.Append("/subscriptions/{subscription_id}/payment-method");
+
+            // process optional template parameters.
+            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
+            {
+                { "subscription_id", subscriptionId },
+            });
+
+            // append request with appropriate headers and parameters
+            var headers = new Dictionary<string, string>()
+            {
+                { "user-agent", this.UserAgent },
+                { "accept", "application/json" },
+                { "content-type", "application/json; charset=utf-8" },
+                { "idempotency-key", idempotencyKey },
+            };
+
+            // append body params.
+            var bodyText = ApiHelper.JsonSerialize(request);
+
+            // prepare the API call request to fetch the response.
+            HttpRequest httpRequest = this.GetClientInstance().PatchBody(queryBuilder.ToString(), headers, bodyText);
+
+            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
+
+            // invoke request and get response.
+            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+            HttpContext context = new HttpContext(httpRequest, response);
+
+            // handle errors defined at the API level.
+            this.ValidateResponse(response, context);
+
+            return ApiHelper.JsonDeserialize<Models.GetSubscriptionResponse>(response.Body);
+        }
+
+        /// <summary>
+        /// Creates a increment.
+        /// </summary>
+        /// <param name="subscriptionId">Required parameter: Subscription id.</param>
+        /// <param name="request">Required parameter: Request for creating a increment.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <returns>Returns the Models.GetIncrementResponse response from the API call.</returns>
+        public Models.GetIncrementResponse CreateIncrement(
+                string subscriptionId,
+                Models.CreateIncrementRequest request,
+                string idempotencyKey = null)
+        {
+            Task<Models.GetIncrementResponse> t = this.CreateIncrementAsync(subscriptionId, request, idempotencyKey);
+            ApiHelper.RunTaskSynchronously(t);
+            return t.Result;
+        }
+
+        /// <summary>
+        /// Creates a increment.
+        /// </summary>
+        /// <param name="subscriptionId">Required parameter: Subscription id.</param>
+        /// <param name="request">Required parameter: Request for creating a increment.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetIncrementResponse response from the API call.</returns>
+        public async Task<Models.GetIncrementResponse> CreateIncrementAsync(
+                string subscriptionId,
+                Models.CreateIncrementRequest request,
+                string idempotencyKey = null,
+                CancellationToken cancellationToken = default)
+        {
+            // the base uri for api requests.
+            string baseUri = this.Config.GetBaseUri();
+
+            // prepare query string for API call.
+            StringBuilder queryBuilder = new StringBuilder(baseUri);
+            queryBuilder.Append("/subscriptions/{subscription_id}/increments");
+
+            // process optional template parameters.
+            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
+            {
+                { "subscription_id", subscriptionId },
+            });
+
+            // append request with appropriate headers and parameters
+            var headers = new Dictionary<string, string>()
+            {
+                { "user-agent", this.UserAgent },
+                { "accept", "application/json" },
+                { "content-type", "application/json; charset=utf-8" },
+                { "idempotency-key", idempotencyKey },
+            };
+
+            // append body params.
+            var bodyText = ApiHelper.JsonSerialize(request);
+
+            // prepare the API call request to fetch the response.
+            HttpRequest httpRequest = this.GetClientInstance().PostBody(queryBuilder.ToString(), headers, bodyText);
+
+            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
+
+            // invoke request and get response.
+            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+            HttpContext context = new HttpContext(httpRequest, response);
+
+            // handle errors defined at the API level.
+            this.ValidateResponse(response, context);
+
+            return ApiHelper.JsonDeserialize<Models.GetIncrementResponse>(response.Body);
+        }
+
+        /// <summary>
+        /// Creates a usage.
+        /// </summary>
+        /// <param name="subscriptionId">Required parameter: Subscription Id.</param>
+        /// <param name="itemId">Required parameter: Item id.</param>
+        /// <param name="body">Required parameter: Request for creating a usage.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <returns>Returns the Models.GetUsageResponse response from the API call.</returns>
+        public Models.GetUsageResponse CreateUsage(
+                string subscriptionId,
+                string itemId,
+                Models.CreateUsageRequest body,
+                string idempotencyKey = null)
+        {
+            Task<Models.GetUsageResponse> t = this.CreateUsageAsync(subscriptionId, itemId, body, idempotencyKey);
+            ApiHelper.RunTaskSynchronously(t);
+            return t.Result;
+        }
+
+        /// <summary>
+        /// Creates a usage.
+        /// </summary>
+        /// <param name="subscriptionId">Required parameter: Subscription Id.</param>
+        /// <param name="itemId">Required parameter: Item id.</param>
+        /// <param name="body">Required parameter: Request for creating a usage.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetUsageResponse response from the API call.</returns>
+        public async Task<Models.GetUsageResponse> CreateUsageAsync(
+                string subscriptionId,
+                string itemId,
+                Models.CreateUsageRequest body,
+                string idempotencyKey = null,
+                CancellationToken cancellationToken = default)
+        {
+            // the base uri for api requests.
+            string baseUri = this.Config.GetBaseUri();
+
+            // prepare query string for API call.
+            StringBuilder queryBuilder = new StringBuilder(baseUri);
+            queryBuilder.Append("/subscriptions/{subscription_id}/items/{item_id}/usages");
+
+            // process optional template parameters.
+            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
+            {
+                { "subscription_id", subscriptionId },
+                { "item_id", itemId },
+            });
+
+            // append request with appropriate headers and parameters
+            var headers = new Dictionary<string, string>()
+            {
+                { "user-agent", this.UserAgent },
+                { "accept", "application/json" },
+                { "content-type", "application/json; charset=utf-8" },
+                { "idempotency-key", idempotencyKey },
+            };
+
+            // append body params.
+            var bodyText = ApiHelper.JsonSerialize(body);
+
+            // prepare the API call request to fetch the response.
+            HttpRequest httpRequest = this.GetClientInstance().PostBody(queryBuilder.ToString(), headers, bodyText);
+
+            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
+
+            // invoke request and get response.
+            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+            HttpContext context = new HttpContext(httpRequest, response);
+
+            // handle errors defined at the API level.
+            this.ValidateResponse(response, context);
+
+            return ApiHelper.JsonDeserialize<Models.GetUsageResponse>(response.Body);
+        }
+
+        /// <summary>
+        /// GetSubscriptionCycles EndPoint.
+        /// </summary>
+        /// <param name="subscriptionId">Required parameter: Subscription Id.</param>
+        /// <param name="page">Required parameter: Page number.</param>
+        /// <param name="size">Required parameter: Page size.</param>
+        /// <returns>Returns the Models.ListCyclesResponse response from the API call.</returns>
+        public Models.ListCyclesResponse GetSubscriptionCycles(
+                string subscriptionId,
+                string page,
+                string size)
+        {
+            Task<Models.ListCyclesResponse> t = this.GetSubscriptionCyclesAsync(subscriptionId, page, size);
+            ApiHelper.RunTaskSynchronously(t);
+            return t.Result;
+        }
+
+        /// <summary>
+        /// GetSubscriptionCycles EndPoint.
+        /// </summary>
+        /// <param name="subscriptionId">Required parameter: Subscription Id.</param>
+        /// <param name="page">Required parameter: Page number.</param>
+        /// <param name="size">Required parameter: Page size.</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.ListCyclesResponse response from the API call.</returns>
+        public async Task<Models.ListCyclesResponse> GetSubscriptionCyclesAsync(
+                string subscriptionId,
+                string page,
+                string size,
+                CancellationToken cancellationToken = default)
+        {
+            // the base uri for api requests.
+            string baseUri = this.Config.GetBaseUri();
+
+            // prepare query string for API call.
+            StringBuilder queryBuilder = new StringBuilder(baseUri);
+            queryBuilder.Append("/subscriptions/{subscription_id}/cycles");
+
+            // process optional template parameters.
+            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
+            {
+                { "subscription_id", subscriptionId },
+            });
+
+            // prepare specfied query parameters.
+            var queryParams = new Dictionary<string, object>()
+            {
+                { "page", page },
+                { "size", size },
+            };
+
+            // append request with appropriate headers and parameters
+            var headers = new Dictionary<string, string>()
+            {
+                { "user-agent", this.UserAgent },
+                { "accept", "application/json" },
+            };
+
+            // prepare the API call request to fetch the response.
+            HttpRequest httpRequest = this.GetClientInstance().Get(queryBuilder.ToString(), headers, queryParameters: queryParams);
+
+            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
+
+            // invoke request and get response.
+            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+            HttpContext context = new HttpContext(httpRequest, response);
+
+            // handle errors defined at the API level.
+            this.ValidateResponse(response, context);
+
+            return ApiHelper.JsonDeserialize<Models.ListCyclesResponse>(response.Body);
+        }
+
+        /// <summary>
+        /// Updates the billing date from a subscription.
+        /// </summary>
+        /// <param name="subscriptionId">Required parameter: The subscription id.</param>
+        /// <param name="request">Required parameter: Request for updating the subscription billing date.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <returns>Returns the Models.GetSubscriptionResponse response from the API call.</returns>
+        public Models.GetSubscriptionResponse UpdateSubscriptionBillingDate(
+                string subscriptionId,
+                Models.UpdateSubscriptionBillingDateRequest request,
+                string idempotencyKey = null)
+        {
+            Task<Models.GetSubscriptionResponse> t = this.UpdateSubscriptionBillingDateAsync(subscriptionId, request, idempotencyKey);
+            ApiHelper.RunTaskSynchronously(t);
+            return t.Result;
+        }
+
+        /// <summary>
+        /// Updates the billing date from a subscription.
+        /// </summary>
+        /// <param name="subscriptionId">Required parameter: The subscription id.</param>
+        /// <param name="request">Required parameter: Request for updating the subscription billing date.</param>
+        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.GetSubscriptionResponse response from the API call.</returns>
+        public async Task<Models.GetSubscriptionResponse> UpdateSubscriptionBillingDateAsync(
+                string subscriptionId,
+                Models.UpdateSubscriptionBillingDateRequest request,
+                string idempotencyKey = null,
+                CancellationToken cancellationToken = default)
+        {
+            // the base uri for api requests.
+            string baseUri = this.Config.GetBaseUri();
+
+            // prepare query string for API call.
+            StringBuilder queryBuilder = new StringBuilder(baseUri);
+            queryBuilder.Append("/subscriptions/{subscription_id}/billing-date");
+
+            // process optional template parameters.
+            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
+            {
+                { "subscription_id", subscriptionId },
+            });
+
+            // append request with appropriate headers and parameters
+            var headers = new Dictionary<string, string>()
+            {
+                { "user-agent", this.UserAgent },
+                { "accept", "application/json" },
+                { "content-type", "application/json; charset=utf-8" },
+                { "idempotency-key", idempotencyKey },
+            };
+
+            // append body params.
+            var bodyText = ApiHelper.JsonSerialize(request);
+
+            // prepare the API call request to fetch the response.
+            HttpRequest httpRequest = this.GetClientInstance().PatchBody(queryBuilder.ToString(), headers, bodyText);
+
+            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
+
+            // invoke request and get response.
+            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+            HttpContext context = new HttpContext(httpRequest, response);
+
+            // handle errors defined at the API level.
+            this.ValidateResponse(response, context);
+
+            return ApiHelper.JsonDeserialize<Models.GetSubscriptionResponse>(response.Body);
+        }
+
+        /// <summary>
         /// Updates the start at date from a subscription.
         /// </summary>
         /// <param name="subscriptionId">Required parameter: The subscription id.</param>
@@ -1979,514 +2487,6 @@ namespace PagarmeApiSDK.Standard.Controllers
             this.ValidateResponse(response, context);
 
             return ApiHelper.JsonDeserialize<Models.GetSubscriptionResponse>(response.Body);
-        }
-
-        /// <summary>
-        /// Updates a subscription item.
-        /// </summary>
-        /// <param name="subscriptionId">Required parameter: Subscription Id.</param>
-        /// <param name="itemId">Required parameter: Item id.</param>
-        /// <param name="body">Required parameter: Request for updating a subscription item.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <returns>Returns the Models.GetSubscriptionItemResponse response from the API call.</returns>
-        public Models.GetSubscriptionItemResponse UpdateSubscriptionItem(
-                string subscriptionId,
-                string itemId,
-                Models.UpdateSubscriptionItemRequest body,
-                string idempotencyKey = null)
-        {
-            Task<Models.GetSubscriptionItemResponse> t = this.UpdateSubscriptionItemAsync(subscriptionId, itemId, body, idempotencyKey);
-            ApiHelper.RunTaskSynchronously(t);
-            return t.Result;
-        }
-
-        /// <summary>
-        /// Updates a subscription item.
-        /// </summary>
-        /// <param name="subscriptionId">Required parameter: Subscription Id.</param>
-        /// <param name="itemId">Required parameter: Item id.</param>
-        /// <param name="body">Required parameter: Request for updating a subscription item.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetSubscriptionItemResponse response from the API call.</returns>
-        public async Task<Models.GetSubscriptionItemResponse> UpdateSubscriptionItemAsync(
-                string subscriptionId,
-                string itemId,
-                Models.UpdateSubscriptionItemRequest body,
-                string idempotencyKey = null,
-                CancellationToken cancellationToken = default)
-        {
-            // the base uri for api requests.
-            string baseUri = this.Config.GetBaseUri();
-
-            // prepare query string for API call.
-            StringBuilder queryBuilder = new StringBuilder(baseUri);
-            queryBuilder.Append("/subscriptions/{subscription_id}/items/{item_id}");
-
-            // process optional template parameters.
-            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
-            {
-                { "subscription_id", subscriptionId },
-                { "item_id", itemId },
-            });
-
-            // append request with appropriate headers and parameters
-            var headers = new Dictionary<string, string>()
-            {
-                { "user-agent", this.UserAgent },
-                { "accept", "application/json" },
-                { "content-type", "application/json; charset=utf-8" },
-                { "idempotency-key", idempotencyKey },
-            };
-
-            // append body params.
-            var bodyText = ApiHelper.JsonSerialize(body);
-
-            // prepare the API call request to fetch the response.
-            HttpRequest httpRequest = this.GetClientInstance().PutBody(queryBuilder.ToString(), headers, bodyText);
-
-            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
-
-            // invoke request and get response.
-            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
-            HttpContext context = new HttpContext(httpRequest, response);
-
-            // handle errors defined at the API level.
-            this.ValidateResponse(response, context);
-
-            return ApiHelper.JsonDeserialize<Models.GetSubscriptionItemResponse>(response.Body);
-        }
-
-        /// <summary>
-        /// Creates a new Subscription item.
-        /// </summary>
-        /// <param name="subscriptionId">Required parameter: Subscription id.</param>
-        /// <param name="request">Required parameter: Request for creating a subscription item.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <returns>Returns the Models.GetSubscriptionItemResponse response from the API call.</returns>
-        public Models.GetSubscriptionItemResponse CreateSubscriptionItem(
-                string subscriptionId,
-                Models.CreateSubscriptionItemRequest request,
-                string idempotencyKey = null)
-        {
-            Task<Models.GetSubscriptionItemResponse> t = this.CreateSubscriptionItemAsync(subscriptionId, request, idempotencyKey);
-            ApiHelper.RunTaskSynchronously(t);
-            return t.Result;
-        }
-
-        /// <summary>
-        /// Creates a new Subscription item.
-        /// </summary>
-        /// <param name="subscriptionId">Required parameter: Subscription id.</param>
-        /// <param name="request">Required parameter: Request for creating a subscription item.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetSubscriptionItemResponse response from the API call.</returns>
-        public async Task<Models.GetSubscriptionItemResponse> CreateSubscriptionItemAsync(
-                string subscriptionId,
-                Models.CreateSubscriptionItemRequest request,
-                string idempotencyKey = null,
-                CancellationToken cancellationToken = default)
-        {
-            // the base uri for api requests.
-            string baseUri = this.Config.GetBaseUri();
-
-            // prepare query string for API call.
-            StringBuilder queryBuilder = new StringBuilder(baseUri);
-            queryBuilder.Append("/subscriptions/{subscription_id}/items");
-
-            // process optional template parameters.
-            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
-            {
-                { "subscription_id", subscriptionId },
-            });
-
-            // append request with appropriate headers and parameters
-            var headers = new Dictionary<string, string>()
-            {
-                { "user-agent", this.UserAgent },
-                { "accept", "application/json" },
-                { "content-type", "application/json; charset=utf-8" },
-                { "idempotency-key", idempotencyKey },
-            };
-
-            // append body params.
-            var bodyText = ApiHelper.JsonSerialize(request);
-
-            // prepare the API call request to fetch the response.
-            HttpRequest httpRequest = this.GetClientInstance().PostBody(queryBuilder.ToString(), headers, bodyText);
-
-            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
-
-            // invoke request and get response.
-            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
-            HttpContext context = new HttpContext(httpRequest, response);
-
-            // handle errors defined at the API level.
-            this.ValidateResponse(response, context);
-
-            return ApiHelper.JsonDeserialize<Models.GetSubscriptionItemResponse>(response.Body);
-        }
-
-        /// <summary>
-        /// Gets a subscription.
-        /// </summary>
-        /// <param name="subscriptionId">Required parameter: Subscription id.</param>
-        /// <returns>Returns the Models.GetSubscriptionResponse response from the API call.</returns>
-        public Models.GetSubscriptionResponse GetSubscription(
-                string subscriptionId)
-        {
-            Task<Models.GetSubscriptionResponse> t = this.GetSubscriptionAsync(subscriptionId);
-            ApiHelper.RunTaskSynchronously(t);
-            return t.Result;
-        }
-
-        /// <summary>
-        /// Gets a subscription.
-        /// </summary>
-        /// <param name="subscriptionId">Required parameter: Subscription id.</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetSubscriptionResponse response from the API call.</returns>
-        public async Task<Models.GetSubscriptionResponse> GetSubscriptionAsync(
-                string subscriptionId,
-                CancellationToken cancellationToken = default)
-        {
-            // the base uri for api requests.
-            string baseUri = this.Config.GetBaseUri();
-
-            // prepare query string for API call.
-            StringBuilder queryBuilder = new StringBuilder(baseUri);
-            queryBuilder.Append("/subscriptions/{subscription_id}");
-
-            // process optional template parameters.
-            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
-            {
-                { "subscription_id", subscriptionId },
-            });
-
-            // append request with appropriate headers and parameters
-            var headers = new Dictionary<string, string>()
-            {
-                { "user-agent", this.UserAgent },
-                { "accept", "application/json" },
-            };
-
-            // prepare the API call request to fetch the response.
-            HttpRequest httpRequest = this.GetClientInstance().Get(queryBuilder.ToString(), headers);
-
-            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
-
-            // invoke request and get response.
-            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
-            HttpContext context = new HttpContext(httpRequest, response);
-
-            // handle errors defined at the API level.
-            this.ValidateResponse(response, context);
-
-            return ApiHelper.JsonDeserialize<Models.GetSubscriptionResponse>(response.Body);
-        }
-
-        /// <summary>
-        /// Lists all usages from a subscription item.
-        /// </summary>
-        /// <param name="subscriptionId">Required parameter: The subscription id.</param>
-        /// <param name="itemId">Required parameter: The subscription item id.</param>
-        /// <param name="page">Optional parameter: Page number.</param>
-        /// <param name="size">Optional parameter: Page size.</param>
-        /// <param name="code">Optional parameter: Identification code in the client system.</param>
-        /// <param name="mGroup">Optional parameter: Identification group in the client system.</param>
-        /// <param name="usedSince">Optional parameter: Example: .</param>
-        /// <param name="usedUntil">Optional parameter: Example: .</param>
-        /// <returns>Returns the Models.ListUsagesResponse response from the API call.</returns>
-        public Models.ListUsagesResponse GetUsages(
-                string subscriptionId,
-                string itemId,
-                int? page = null,
-                int? size = null,
-                string code = null,
-                string mGroup = null,
-                DateTime? usedSince = null,
-                DateTime? usedUntil = null)
-        {
-            Task<Models.ListUsagesResponse> t = this.GetUsagesAsync(subscriptionId, itemId, page, size, code, mGroup, usedSince, usedUntil);
-            ApiHelper.RunTaskSynchronously(t);
-            return t.Result;
-        }
-
-        /// <summary>
-        /// Lists all usages from a subscription item.
-        /// </summary>
-        /// <param name="subscriptionId">Required parameter: The subscription id.</param>
-        /// <param name="itemId">Required parameter: The subscription item id.</param>
-        /// <param name="page">Optional parameter: Page number.</param>
-        /// <param name="size">Optional parameter: Page size.</param>
-        /// <param name="code">Optional parameter: Identification code in the client system.</param>
-        /// <param name="mGroup">Optional parameter: Identification group in the client system.</param>
-        /// <param name="usedSince">Optional parameter: Example: .</param>
-        /// <param name="usedUntil">Optional parameter: Example: .</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.ListUsagesResponse response from the API call.</returns>
-        public async Task<Models.ListUsagesResponse> GetUsagesAsync(
-                string subscriptionId,
-                string itemId,
-                int? page = null,
-                int? size = null,
-                string code = null,
-                string mGroup = null,
-                DateTime? usedSince = null,
-                DateTime? usedUntil = null,
-                CancellationToken cancellationToken = default)
-        {
-            // the base uri for api requests.
-            string baseUri = this.Config.GetBaseUri();
-
-            // prepare query string for API call.
-            StringBuilder queryBuilder = new StringBuilder(baseUri);
-            queryBuilder.Append("/subscriptions/{subscription_id}/items/{item_id}/usages");
-
-            // process optional template parameters.
-            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
-            {
-                { "subscription_id", subscriptionId },
-                { "item_id", itemId },
-            });
-
-            // prepare specfied query parameters.
-            var queryParams = new Dictionary<string, object>()
-            {
-                { "page", page },
-                { "size", size },
-                { "code", code },
-                { "group", mGroup },
-                { "used_since", usedSince.HasValue ? usedSince.Value.ToString("yyyy'-'MM'-'dd'T'HH':'mm':'ss.FFFFFFFK") : null },
-                { "used_until", usedUntil.HasValue ? usedUntil.Value.ToString("yyyy'-'MM'-'dd'T'HH':'mm':'ss.FFFFFFFK") : null },
-            };
-
-            // append request with appropriate headers and parameters
-            var headers = new Dictionary<string, string>()
-            {
-                { "user-agent", this.UserAgent },
-                { "accept", "application/json" },
-            };
-
-            // prepare the API call request to fetch the response.
-            HttpRequest httpRequest = this.GetClientInstance().Get(queryBuilder.ToString(), headers, queryParameters: queryParams);
-
-            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
-
-            // invoke request and get response.
-            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
-            HttpContext context = new HttpContext(httpRequest, response);
-
-            // handle errors defined at the API level.
-            this.ValidateResponse(response, context);
-
-            return ApiHelper.JsonDeserialize<Models.ListUsagesResponse>(response.Body);
-        }
-
-        /// <summary>
-        /// UpdateLatestPeriodEndAt EndPoint.
-        /// </summary>
-        /// <param name="subscriptionId">Required parameter: Example: .</param>
-        /// <param name="request">Required parameter: Request for updating the end date of the current signature cycle.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <returns>Returns the Models.GetSubscriptionResponse response from the API call.</returns>
-        public Models.GetSubscriptionResponse UpdateLatestPeriodEndAt(
-                string subscriptionId,
-                Models.UpdateCurrentCycleEndDateRequest request,
-                string idempotencyKey = null)
-        {
-            Task<Models.GetSubscriptionResponse> t = this.UpdateLatestPeriodEndAtAsync(subscriptionId, request, idempotencyKey);
-            ApiHelper.RunTaskSynchronously(t);
-            return t.Result;
-        }
-
-        /// <summary>
-        /// UpdateLatestPeriodEndAt EndPoint.
-        /// </summary>
-        /// <param name="subscriptionId">Required parameter: Example: .</param>
-        /// <param name="request">Required parameter: Request for updating the end date of the current signature cycle.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetSubscriptionResponse response from the API call.</returns>
-        public async Task<Models.GetSubscriptionResponse> UpdateLatestPeriodEndAtAsync(
-                string subscriptionId,
-                Models.UpdateCurrentCycleEndDateRequest request,
-                string idempotencyKey = null,
-                CancellationToken cancellationToken = default)
-        {
-            // the base uri for api requests.
-            string baseUri = this.Config.GetBaseUri();
-
-            // prepare query string for API call.
-            StringBuilder queryBuilder = new StringBuilder(baseUri);
-            queryBuilder.Append("/subscriptions/{subscription_id}/periods/latest/end-at");
-
-            // process optional template parameters.
-            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
-            {
-                { "subscription_id", subscriptionId },
-            });
-
-            // append request with appropriate headers and parameters
-            var headers = new Dictionary<string, string>()
-            {
-                { "user-agent", this.UserAgent },
-                { "accept", "application/json" },
-                { "content-type", "application/json; charset=utf-8" },
-                { "idempotency-key", idempotencyKey },
-            };
-
-            // append body params.
-            var bodyText = ApiHelper.JsonSerialize(request);
-
-            // prepare the API call request to fetch the response.
-            HttpRequest httpRequest = this.GetClientInstance().PatchBody(queryBuilder.ToString(), headers, bodyText);
-
-            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
-
-            // invoke request and get response.
-            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
-            HttpContext context = new HttpContext(httpRequest, response);
-
-            // handle errors defined at the API level.
-            this.ValidateResponse(response, context);
-
-            return ApiHelper.JsonDeserialize<Models.GetSubscriptionResponse>(response.Body);
-        }
-
-        /// <summary>
-        /// Atualização do valor mínimo da assinatura.
-        /// </summary>
-        /// <param name="subscriptionId">Required parameter: Subscription Id.</param>
-        /// <param name="request">Required parameter: Request da requisição com o valor mínimo que será configurado.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <returns>Returns the Models.GetSubscriptionResponse response from the API call.</returns>
-        public Models.GetSubscriptionResponse UpdateSubscriptionMiniumPrice(
-                string subscriptionId,
-                Models.UpdateSubscriptionMinimumPriceRequest request,
-                string idempotencyKey = null)
-        {
-            Task<Models.GetSubscriptionResponse> t = this.UpdateSubscriptionMiniumPriceAsync(subscriptionId, request, idempotencyKey);
-            ApiHelper.RunTaskSynchronously(t);
-            return t.Result;
-        }
-
-        /// <summary>
-        /// Atualização do valor mínimo da assinatura.
-        /// </summary>
-        /// <param name="subscriptionId">Required parameter: Subscription Id.</param>
-        /// <param name="request">Required parameter: Request da requisição com o valor mínimo que será configurado.</param>
-        /// <param name="idempotencyKey">Optional parameter: Example: .</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetSubscriptionResponse response from the API call.</returns>
-        public async Task<Models.GetSubscriptionResponse> UpdateSubscriptionMiniumPriceAsync(
-                string subscriptionId,
-                Models.UpdateSubscriptionMinimumPriceRequest request,
-                string idempotencyKey = null,
-                CancellationToken cancellationToken = default)
-        {
-            // the base uri for api requests.
-            string baseUri = this.Config.GetBaseUri();
-
-            // prepare query string for API call.
-            StringBuilder queryBuilder = new StringBuilder(baseUri);
-            queryBuilder.Append("/subscriptions/{subscription_id}/minimum_price");
-
-            // process optional template parameters.
-            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
-            {
-                { "subscription_id", subscriptionId },
-            });
-
-            // append request with appropriate headers and parameters
-            var headers = new Dictionary<string, string>()
-            {
-                { "user-agent", this.UserAgent },
-                { "accept", "application/json" },
-                { "content-type", "application/json; charset=utf-8" },
-                { "idempotency-key", idempotencyKey },
-            };
-
-            // append body params.
-            var bodyText = ApiHelper.JsonSerialize(request);
-
-            // prepare the API call request to fetch the response.
-            HttpRequest httpRequest = this.GetClientInstance().PatchBody(queryBuilder.ToString(), headers, bodyText);
-
-            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
-
-            // invoke request and get response.
-            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
-            HttpContext context = new HttpContext(httpRequest, response);
-
-            // handle errors defined at the API level.
-            this.ValidateResponse(response, context);
-
-            return ApiHelper.JsonDeserialize<Models.GetSubscriptionResponse>(response.Body);
-        }
-
-        /// <summary>
-        /// GetSubscriptionCycleById EndPoint.
-        /// </summary>
-        /// <param name="subscriptionId">Required parameter: The subscription id.</param>
-        /// <param name="cycleId">Required parameter: Example: .</param>
-        /// <returns>Returns the Models.GetPeriodResponse response from the API call.</returns>
-        public Models.GetPeriodResponse GetSubscriptionCycleById(
-                string subscriptionId,
-                string cycleId)
-        {
-            Task<Models.GetPeriodResponse> t = this.GetSubscriptionCycleByIdAsync(subscriptionId, cycleId);
-            ApiHelper.RunTaskSynchronously(t);
-            return t.Result;
-        }
-
-        /// <summary>
-        /// GetSubscriptionCycleById EndPoint.
-        /// </summary>
-        /// <param name="subscriptionId">Required parameter: The subscription id.</param>
-        /// <param name="cycleId">Required parameter: Example: .</param>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.GetPeriodResponse response from the API call.</returns>
-        public async Task<Models.GetPeriodResponse> GetSubscriptionCycleByIdAsync(
-                string subscriptionId,
-                string cycleId,
-                CancellationToken cancellationToken = default)
-        {
-            // the base uri for api requests.
-            string baseUri = this.Config.GetBaseUri();
-
-            // prepare query string for API call.
-            StringBuilder queryBuilder = new StringBuilder(baseUri);
-            queryBuilder.Append("/subscriptions/{subscription_id}/cycles/{cycleId}");
-
-            // process optional template parameters.
-            ApiHelper.AppendUrlWithTemplateParameters(queryBuilder, new Dictionary<string, object>()
-            {
-                { "subscription_id", subscriptionId },
-                { "cycleId", cycleId },
-            });
-
-            // append request with appropriate headers and parameters
-            var headers = new Dictionary<string, string>()
-            {
-                { "user-agent", this.UserAgent },
-                { "accept", "application/json" },
-            };
-
-            // prepare the API call request to fetch the response.
-            HttpRequest httpRequest = this.GetClientInstance().Get(queryBuilder.ToString(), headers);
-
-            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
-
-            // invoke request and get response.
-            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
-            HttpContext context = new HttpContext(httpRequest, response);
-
-            // handle errors defined at the API level.
-            this.ValidateResponse(response, context);
-
-            return ApiHelper.JsonDeserialize<Models.GetPeriodResponse>(response.Body);
         }
 
         /// <summary>

--- a/PagarmeApiSDK.Standard/Controllers/TransfersController.cs
+++ b/PagarmeApiSDK.Standard/Controllers/TransfersController.cs
@@ -37,6 +37,53 @@ namespace PagarmeApiSDK.Standard.Controllers
         }
 
         /// <summary>
+        /// Gets all transfers.
+        /// </summary>
+        /// <returns>Returns the Models.ListTransfers response from the API call.</returns>
+        public Models.ListTransfers GetTransfers()
+        {
+            Task<Models.ListTransfers> t = this.GetTransfersAsync();
+            ApiHelper.RunTaskSynchronously(t);
+            return t.Result;
+        }
+
+        /// <summary>
+        /// Gets all transfers.
+        /// </summary>
+        /// <param name="cancellationToken"> cancellationToken. </param>
+        /// <returns>Returns the Models.ListTransfers response from the API call.</returns>
+        public async Task<Models.ListTransfers> GetTransfersAsync(CancellationToken cancellationToken = default)
+        {
+            // the base uri for api requests.
+            string baseUri = this.Config.GetBaseUri();
+
+            // prepare query string for API call.
+            StringBuilder queryBuilder = new StringBuilder(baseUri);
+            queryBuilder.Append("/transfers");
+
+            // append request with appropriate headers and parameters
+            var headers = new Dictionary<string, string>()
+            {
+                { "user-agent", this.UserAgent },
+                { "accept", "application/json" },
+            };
+
+            // prepare the API call request to fetch the response.
+            HttpRequest httpRequest = this.GetClientInstance().Get(queryBuilder.ToString(), headers);
+
+            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
+
+            // invoke request and get response.
+            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+            HttpContext context = new HttpContext(httpRequest, response);
+
+            // handle errors defined at the API level.
+            this.ValidateResponse(response, context);
+
+            return ApiHelper.JsonDeserialize<Models.ListTransfers>(response.Body);
+        }
+
+        /// <summary>
         /// GetTransferById EndPoint.
         /// </summary>
         /// <param name="transferId">Required parameter: Example: .</param>
@@ -148,53 +195,6 @@ namespace PagarmeApiSDK.Standard.Controllers
             this.ValidateResponse(response, context);
 
             return ApiHelper.JsonDeserialize<Models.GetTransfer>(response.Body);
-        }
-
-        /// <summary>
-        /// Gets all transfers.
-        /// </summary>
-        /// <returns>Returns the Models.ListTransfers response from the API call.</returns>
-        public Models.ListTransfers GetTransfers()
-        {
-            Task<Models.ListTransfers> t = this.GetTransfersAsync();
-            ApiHelper.RunTaskSynchronously(t);
-            return t.Result;
-        }
-
-        /// <summary>
-        /// Gets all transfers.
-        /// </summary>
-        /// <param name="cancellationToken"> cancellationToken. </param>
-        /// <returns>Returns the Models.ListTransfers response from the API call.</returns>
-        public async Task<Models.ListTransfers> GetTransfersAsync(CancellationToken cancellationToken = default)
-        {
-            // the base uri for api requests.
-            string baseUri = this.Config.GetBaseUri();
-
-            // prepare query string for API call.
-            StringBuilder queryBuilder = new StringBuilder(baseUri);
-            queryBuilder.Append("/transfers");
-
-            // append request with appropriate headers and parameters
-            var headers = new Dictionary<string, string>()
-            {
-                { "user-agent", this.UserAgent },
-                { "accept", "application/json" },
-            };
-
-            // prepare the API call request to fetch the response.
-            HttpRequest httpRequest = this.GetClientInstance().Get(queryBuilder.ToString(), headers);
-
-            httpRequest = await this.AuthManagers["global"].ApplyAsync(httpRequest).ConfigureAwait(false);
-
-            // invoke request and get response.
-            HttpStringResponse response = await this.GetClientInstance().ExecuteAsStringAsync(httpRequest, cancellationToken).ConfigureAwait(false);
-            HttpContext context = new HttpContext(httpRequest, response);
-
-            // handle errors defined at the API level.
-            this.ValidateResponse(response, context);
-
-            return ApiHelper.JsonDeserialize<Models.ListTransfers>(response.Body);
         }
     }
 }

--- a/PagarmeApiSDK.Standard/IPagarmeApiSDKClient.cs
+++ b/PagarmeApiSDK.Standard/IPagarmeApiSDKClient.cs
@@ -12,6 +12,11 @@ namespace PagarmeApiSDK.Standard
     public interface IPagarmeApiSDKClient : IConfiguration
     {
         /// <summary>
+        /// Gets instance for IOrdersController.
+        /// </summary>
+        IOrdersController OrdersController { get; }
+
+        /// <summary>
         /// Gets instance for IPlansController.
         /// </summary>
         IPlansController PlansController { get; }
@@ -25,11 +30,6 @@ namespace PagarmeApiSDK.Standard
         /// Gets instance for IInvoicesController.
         /// </summary>
         IInvoicesController InvoicesController { get; }
-
-        /// <summary>
-        /// Gets instance for IOrdersController.
-        /// </summary>
-        IOrdersController OrdersController { get; }
 
         /// <summary>
         /// Gets instance for ICustomersController.
@@ -47,19 +47,14 @@ namespace PagarmeApiSDK.Standard
         IChargesController ChargesController { get; }
 
         /// <summary>
-        /// Gets instance for ITransfersController.
-        /// </summary>
-        ITransfersController TransfersController { get; }
-
-        /// <summary>
         /// Gets instance for ITokensController.
         /// </summary>
         ITokensController TokensController { get; }
 
         /// <summary>
-        /// Gets instance for ISellersController.
+        /// Gets instance for ITransfersController.
         /// </summary>
-        ISellersController SellersController { get; }
+        ITransfersController TransfersController { get; }
 
         /// <summary>
         /// Gets instance for ITransactionsController.

--- a/PagarmeApiSDK.Standard/Models/CreateOrderItemRequest.cs
+++ b/PagarmeApiSDK.Standard/Models/CreateOrderItemRequest.cs
@@ -35,23 +35,17 @@ namespace PagarmeApiSDK.Standard.Models
         /// <param name="description">description.</param>
         /// <param name="quantity">quantity.</param>
         /// <param name="category">category.</param>
-        /// <param name="seller">seller.</param>
-        /// <param name="sellerId">seller_id.</param>
         /// <param name="code">code.</param>
         public CreateOrderItemRequest(
             int amount,
             string description,
             int quantity,
             string category,
-            Models.CreateSellerRequest seller = null,
-            string sellerId = null,
             string code = null)
         {
             this.Amount = amount;
             this.Description = description;
             this.Quantity = quantity;
-            this.Seller = seller;
-            this.SellerId = sellerId;
             this.Category = category;
             this.Code = code;
         }
@@ -73,18 +67,6 @@ namespace PagarmeApiSDK.Standard.Models
         /// </summary>
         [JsonProperty("quantity")]
         public int Quantity { get; set; }
-
-        /// <summary>
-        /// Item seller
-        /// </summary>
-        [JsonProperty("seller", NullValueHandling = NullValueHandling.Ignore)]
-        public Models.CreateSellerRequest Seller { get; set; }
-
-        /// <summary>
-        /// seller identificator
-        /// </summary>
-        [JsonProperty("seller_id", NullValueHandling = NullValueHandling.Ignore)]
-        public string SellerId { get; set; }
 
         /// <summary>
         /// Category
@@ -125,8 +107,6 @@ namespace PagarmeApiSDK.Standard.Models
                 this.Amount.Equals(other.Amount) &&
                 ((this.Description == null && other.Description == null) || (this.Description?.Equals(other.Description) == true)) &&
                 this.Quantity.Equals(other.Quantity) &&
-                ((this.Seller == null && other.Seller == null) || (this.Seller?.Equals(other.Seller) == true)) &&
-                ((this.SellerId == null && other.SellerId == null) || (this.SellerId?.Equals(other.SellerId) == true)) &&
                 ((this.Category == null && other.Category == null) || (this.Category?.Equals(other.Category) == true)) &&
                 ((this.Code == null && other.Code == null) || (this.Code?.Equals(other.Code) == true));
         }
@@ -141,8 +121,6 @@ namespace PagarmeApiSDK.Standard.Models
             toStringOutput.Add($"this.Amount = {this.Amount}");
             toStringOutput.Add($"this.Description = {(this.Description == null ? "null" : this.Description == string.Empty ? "" : this.Description)}");
             toStringOutput.Add($"this.Quantity = {this.Quantity}");
-            toStringOutput.Add($"this.Seller = {(this.Seller == null ? "null" : this.Seller.ToString())}");
-            toStringOutput.Add($"this.SellerId = {(this.SellerId == null ? "null" : this.SellerId == string.Empty ? "" : this.SellerId)}");
             toStringOutput.Add($"this.Category = {(this.Category == null ? "null" : this.Category == string.Empty ? "" : this.Category)}");
             toStringOutput.Add($"this.Code = {(this.Code == null ? "null" : this.Code == string.Empty ? "" : this.Code)}");
         }

--- a/PagarmeApiSDK.Standard/Models/GetOrderItemResponse.cs
+++ b/PagarmeApiSDK.Standard/Models/GetOrderItemResponse.cs
@@ -37,21 +37,18 @@ namespace PagarmeApiSDK.Standard.Models
         /// <param name="quantity">quantity.</param>
         /// <param name="category">category.</param>
         /// <param name="code">code.</param>
-        /// <param name="getSellerResponse">GetSellerResponse.</param>
         public GetOrderItemResponse(
             string id,
             int amount,
             string description,
             int quantity,
             string category,
-            string code,
-            Models.GetSellerResponse getSellerResponse = null)
+            string code)
         {
             this.Id = id;
             this.Amount = amount;
             this.Description = description;
             this.Quantity = quantity;
-            this.GetSellerResponse = getSellerResponse;
             this.Category = category;
             this.Code = code;
         }
@@ -79,12 +76,6 @@ namespace PagarmeApiSDK.Standard.Models
         /// </summary>
         [JsonProperty("quantity")]
         public int Quantity { get; set; }
-
-        /// <summary>
-        /// Seller data
-        /// </summary>
-        [JsonProperty("GetSellerResponse", NullValueHandling = NullValueHandling.Ignore)]
-        public Models.GetSellerResponse GetSellerResponse { get; set; }
 
         /// <summary>
         /// Category
@@ -126,7 +117,6 @@ namespace PagarmeApiSDK.Standard.Models
                 this.Amount.Equals(other.Amount) &&
                 ((this.Description == null && other.Description == null) || (this.Description?.Equals(other.Description) == true)) &&
                 this.Quantity.Equals(other.Quantity) &&
-                ((this.GetSellerResponse == null && other.GetSellerResponse == null) || (this.GetSellerResponse?.Equals(other.GetSellerResponse) == true)) &&
                 ((this.Category == null && other.Category == null) || (this.Category?.Equals(other.Category) == true)) &&
                 ((this.Code == null && other.Code == null) || (this.Code?.Equals(other.Code) == true));
         }
@@ -142,7 +132,6 @@ namespace PagarmeApiSDK.Standard.Models
             toStringOutput.Add($"this.Amount = {this.Amount}");
             toStringOutput.Add($"this.Description = {(this.Description == null ? "null" : this.Description == string.Empty ? "" : this.Description)}");
             toStringOutput.Add($"this.Quantity = {this.Quantity}");
-            toStringOutput.Add($"this.GetSellerResponse = {(this.GetSellerResponse == null ? "null" : this.GetSellerResponse.ToString())}");
             toStringOutput.Add($"this.Category = {(this.Category == null ? "null" : this.Category == string.Empty ? "" : this.Category)}");
             toStringOutput.Add($"this.Code = {(this.Code == null ? "null" : this.Code == string.Empty ? "" : this.Code)}");
         }

--- a/PagarmeApiSDK.Standard/Models/GetTransactionResponse.cs
+++ b/PagarmeApiSDK.Standard/Models/GetTransactionResponse.cs
@@ -20,15 +20,15 @@ namespace PagarmeApiSDK.Standard.Models
     /// GetTransactionResponse.
     /// </summary>
     [JsonConverter(typeof(JsonSubtypes), "transaction_type")]
+    [JsonSubtypes.KnownSubType(typeof(GetVoucherTransactionResponse), "voucher")]
     [JsonSubtypes.KnownSubType(typeof(GetBankTransferTransactionResponse), "bank_transfer")]
     [JsonSubtypes.KnownSubType(typeof(GetSafetyPayTransactionResponse), "safetypay")]
-    [JsonSubtypes.KnownSubType(typeof(GetVoucherTransactionResponse), "voucher")]
-    [JsonSubtypes.KnownSubType(typeof(GetBoletoTransactionResponse), "boleto")]
     [JsonSubtypes.KnownSubType(typeof(GetDebitCardTransactionResponse), "debit_card")]
-    [JsonSubtypes.KnownSubType(typeof(GetPrivateLabelTransactionResponse), "private_label")]
+    [JsonSubtypes.KnownSubType(typeof(GetBoletoTransactionResponse), "boleto")]
     [JsonSubtypes.KnownSubType(typeof(GetCashTransactionResponse), "cash")]
-    [JsonSubtypes.KnownSubType(typeof(GetCreditCardTransactionResponse), "credit_card")]
+    [JsonSubtypes.KnownSubType(typeof(GetPrivateLabelTransactionResponse), "private_label")]
     [JsonSubtypes.KnownSubType(typeof(GetPixTransactionResponse), "pix")]
+    [JsonSubtypes.KnownSubType(typeof(GetCreditCardTransactionResponse), "credit_card")]
     public class GetTransactionResponse
     {
         /// <summary>

--- a/PagarmeApiSDK.Standard/PagarmeApiSDK.Standard.csproj
+++ b/PagarmeApiSDK.Standard/PagarmeApiSDK.Standard.csproj
@@ -9,13 +9,13 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>PagarmeApiSDKStandard</AssemblyName>
-    <Version>6.1.0.0</Version>
+    <Version>6.2.0.0</Version>
     <Authors>Pagar.me Pagamentos S/A</Authors>
     <Owners>Pagar.me Pagamentos S/A</Owners>
     <Product>PagarmeApiSDK.Standard</Product>
     <Copyright>Copyright ©  2019</Copyright>
-    <AssemblyVersion>6.1.0.0</AssemblyVersion>
-    <FileVersion>6.1.0.0</FileVersion>
+    <AssemblyVersion>6.2.0.0</AssemblyVersion>
+    <FileVersion>6.2.0.0</FileVersion>
     <Description>.NET client library for the PagarmeApiSDK</Description>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/PagarmeApiSDK.Standard/PagarmeApiSDKClient.cs
+++ b/PagarmeApiSDK.Standard/PagarmeApiSDKClient.cs
@@ -35,16 +35,15 @@ namespace PagarmeApiSDK.Standard
         private readonly IHttpClient httpClient;
         private readonly BasicAuthManager basicAuthManager;
 
+        private readonly Lazy<IOrdersController> orders;
         private readonly Lazy<IPlansController> plans;
         private readonly Lazy<ISubscriptionsController> subscriptions;
         private readonly Lazy<IInvoicesController> invoices;
-        private readonly Lazy<IOrdersController> orders;
         private readonly Lazy<ICustomersController> customers;
         private readonly Lazy<IRecipientsController> recipients;
         private readonly Lazy<IChargesController> charges;
-        private readonly Lazy<ITransfersController> transfers;
         private readonly Lazy<ITokensController> tokens;
-        private readonly Lazy<ISellersController> sellers;
+        private readonly Lazy<ITransfersController> transfers;
         private readonly Lazy<ITransactionsController> transactions;
 
         private PagarmeApiSDKClient(
@@ -60,26 +59,24 @@ namespace PagarmeApiSDK.Standard
             this.authManagers = (authManagers == null) ? new Dictionary<string, IAuthManager>() : new Dictionary<string, IAuthManager>(authManagers);
             this.HttpClientConfiguration = httpClientConfiguration;
 
+            this.orders = new Lazy<IOrdersController>(
+                () => new OrdersController(this, this.httpClient, this.authManagers));
             this.plans = new Lazy<IPlansController>(
                 () => new PlansController(this, this.httpClient, this.authManagers));
             this.subscriptions = new Lazy<ISubscriptionsController>(
                 () => new SubscriptionsController(this, this.httpClient, this.authManagers));
             this.invoices = new Lazy<IInvoicesController>(
                 () => new InvoicesController(this, this.httpClient, this.authManagers));
-            this.orders = new Lazy<IOrdersController>(
-                () => new OrdersController(this, this.httpClient, this.authManagers));
             this.customers = new Lazy<ICustomersController>(
                 () => new CustomersController(this, this.httpClient, this.authManagers));
             this.recipients = new Lazy<IRecipientsController>(
                 () => new RecipientsController(this, this.httpClient, this.authManagers));
             this.charges = new Lazy<IChargesController>(
                 () => new ChargesController(this, this.httpClient, this.authManagers));
-            this.transfers = new Lazy<ITransfersController>(
-                () => new TransfersController(this, this.httpClient, this.authManagers));
             this.tokens = new Lazy<ITokensController>(
                 () => new TokensController(this, this.httpClient, this.authManagers));
-            this.sellers = new Lazy<ISellersController>(
-                () => new SellersController(this, this.httpClient, this.authManagers));
+            this.transfers = new Lazy<ITransfersController>(
+                () => new TransfersController(this, this.httpClient, this.authManagers));
             this.transactions = new Lazy<ITransactionsController>(
                 () => new TransactionsController(this, this.httpClient, this.authManagers));
 
@@ -97,6 +94,11 @@ namespace PagarmeApiSDK.Standard
         }
 
         /// <summary>
+        /// Gets OrdersController controller.
+        /// </summary>
+        public IOrdersController OrdersController => this.orders.Value;
+
+        /// <summary>
         /// Gets PlansController controller.
         /// </summary>
         public IPlansController PlansController => this.plans.Value;
@@ -110,11 +112,6 @@ namespace PagarmeApiSDK.Standard
         /// Gets InvoicesController controller.
         /// </summary>
         public IInvoicesController InvoicesController => this.invoices.Value;
-
-        /// <summary>
-        /// Gets OrdersController controller.
-        /// </summary>
-        public IOrdersController OrdersController => this.orders.Value;
 
         /// <summary>
         /// Gets CustomersController controller.
@@ -132,19 +129,14 @@ namespace PagarmeApiSDK.Standard
         public IChargesController ChargesController => this.charges.Value;
 
         /// <summary>
-        /// Gets TransfersController controller.
-        /// </summary>
-        public ITransfersController TransfersController => this.transfers.Value;
-
-        /// <summary>
         /// Gets TokensController controller.
         /// </summary>
         public ITokensController TokensController => this.tokens.Value;
 
         /// <summary>
-        /// Gets SellersController controller.
+        /// Gets TransfersController controller.
         /// </summary>
-        public ISellersController SellersController => this.sellers.Value;
+        public ITransfersController TransfersController => this.transfers.Value;
 
         /// <summary>
         /// Gets TransactionsController controller.

--- a/PagarmeApiSDK.sln
+++ b/PagarmeApiSDK.sln
@@ -2,7 +2,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.26430.14
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PagarmeApiSDK.Standard", "PagarmeApiSDK.Standard/PagarmeApiSDK.Standard.csproj", "{d15e21e7-cefd-4a8a-933b-a658ae1b68e5}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PagarmeApiSDK.Standard", "PagarmeApiSDK.Standard/PagarmeApiSDK.Standard.csproj", "{ce79c648-d763-47eb-99a9-6b5a13936acb}"
 EndProject
 Global
     GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -10,10 +10,10 @@ Global
         Release|Any CPU = Release|Any CPU
     EndGlobalSection
     GlobalSection(ProjectConfigurationPlatforms) = postSolution
-        {d15e21e7-cefd-4a8a-933b-a658ae1b68e5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-        {d15e21e7-cefd-4a8a-933b-a658ae1b68e5}.Debug|Any CPU.Build.0 = Debug|Any CPU
-        {d15e21e7-cefd-4a8a-933b-a658ae1b68e5}.Release|Any CPU.ActiveCfg = Release|Any CPU
-        {d15e21e7-cefd-4a8a-933b-a658ae1b68e5}.Release|Any CPU.Build.0 = Release|Any CPU
+        {ce79c648-d763-47eb-99a9-6b5a13936acb}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {ce79c648-d763-47eb-99a9-6b5a13936acb}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {ce79c648-d763-47eb-99a9-6b5a13936acb}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {ce79c648-d763-47eb-99a9-6b5a13936acb}.Release|Any CPU.Build.0 = Release|Any CPU
     EndGlobalSection
     GlobalSection(SolutionProperties) = preSolution
         HideSolutionNode = FALSE

--- a/README.md
+++ b/README.md
@@ -96,7 +96,6 @@ Here is the list of errors that the API might throw.
 * [Charges](/doc/controllers/charges.md)
 * [Recipients](/doc/controllers/recipients.md)
 * [Tokens](/doc/controllers/tokens.md)
-* [Sellers](/doc/controllers/sellers.md)
 * [Transactions](/doc/controllers/transactions.md)
 * [Transfers](/doc/controllers/transfers.md)
 

--- a/doc/client.md
+++ b/doc/client.md
@@ -23,16 +23,15 @@ The gateway for the SDK. This class acts as a factory for the Controllers and al
 
 | Name | Description |
 |  --- | --- |
+| OrdersController | Gets OrdersController controller. |
 | PlansController | Gets PlansController controller. |
 | SubscriptionsController | Gets SubscriptionsController controller. |
 | InvoicesController | Gets InvoicesController controller. |
-| OrdersController | Gets OrdersController controller. |
 | CustomersController | Gets CustomersController controller. |
 | RecipientsController | Gets RecipientsController controller. |
 | ChargesController | Gets ChargesController controller. |
-| TransfersController | Gets TransfersController controller. |
 | TokensController | Gets TokensController controller. |
-| SellersController | Gets SellersController controller. |
+| TransfersController | Gets TransfersController controller. |
 | TransactionsController | Gets TransactionsController controller. |
 
 ### Properties

--- a/doc/controllers/charges.md
+++ b/doc/controllers/charges.md
@@ -12,17 +12,17 @@ IChargesController chargesController = client.ChargesController;
 
 * [Update Charge Metadata](/doc/controllers/charges.md#update-charge-metadata)
 * [Update Charge Payment Method](/doc/controllers/charges.md#update-charge-payment-method)
-* [Get Charge Transactions](/doc/controllers/charges.md#get-charge-transactions)
-* [Update Charge Due Date](/doc/controllers/charges.md#update-charge-due-date)
-* [Get Charges](/doc/controllers/charges.md#get-charges)
-* [Capture Charge](/doc/controllers/charges.md#capture-charge)
 * [Update Charge Card](/doc/controllers/charges.md#update-charge-card)
-* [Get Charge](/doc/controllers/charges.md#get-charge)
 * [Get Charges Summary](/doc/controllers/charges.md#get-charges-summary)
-* [Retry Charge](/doc/controllers/charges.md#retry-charge)
-* [Cancel Charge](/doc/controllers/charges.md#cancel-charge)
 * [Create Charge](/doc/controllers/charges.md#create-charge)
+* [Get Charge Transactions](/doc/controllers/charges.md#get-charge-transactions)
+* [Capture Charge](/doc/controllers/charges.md#capture-charge)
+* [Get Charge](/doc/controllers/charges.md#get-charge)
+* [Cancel Charge](/doc/controllers/charges.md#cancel-charge)
+* [Get Charges](/doc/controllers/charges.md#get-charges)
 * [Confirm Payment](/doc/controllers/charges.md#confirm-payment)
+* [Update Charge Due Date](/doc/controllers/charges.md#update-charge-due-date)
+* [Retry Charge](/doc/controllers/charges.md#retry-charge)
 
 
 # Update Charge Metadata
@@ -133,159 +133,6 @@ catch (ApiException e){};
 ```
 
 
-# Get Charge Transactions
-
-```csharp
-GetChargeTransactionsAsync(
-    string chargeId,
-    int? page = null,
-    int? size = null)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `chargeId` | `string` | Template, Required | Charge Id |
-| `page` | `int?` | Query, Optional | Page number |
-| `size` | `int?` | Query, Optional | Page size |
-
-## Response Type
-
-[`Task<Models.ListChargeTransactionsResponse>`](/doc/models/list-charge-transactions-response.md)
-
-## Example Usage
-
-```csharp
-string chargeId = "charge_id8";
-
-try
-{
-    ListChargeTransactionsResponse result = await chargesController.GetChargeTransactionsAsync(chargeId, null, null);
-}
-catch (ApiException e){};
-```
-
-
-# Update Charge Due Date
-
-Updates the due date from a charge
-
-```csharp
-UpdateChargeDueDateAsync(
-    string chargeId,
-    Models.UpdateChargeDueDateRequest request,
-    string idempotencyKey = null)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `chargeId` | `string` | Template, Required | Charge Id |
-| `request` | [`Models.UpdateChargeDueDateRequest`](/doc/models/update-charge-due-date-request.md) | Body, Required | Request for updating the due date |
-| `idempotencyKey` | `string` | Header, Optional | - |
-
-## Response Type
-
-[`Task<Models.GetChargeResponse>`](/doc/models/get-charge-response.md)
-
-## Example Usage
-
-```csharp
-string chargeId = "charge_id8";
-var request = new UpdateChargeDueDateRequest();
-
-try
-{
-    GetChargeResponse result = await chargesController.UpdateChargeDueDateAsync(chargeId, request, null);
-}
-catch (ApiException e){};
-```
-
-
-# Get Charges
-
-Lists all charges
-
-```csharp
-GetChargesAsync(
-    int? page = null,
-    int? size = null,
-    string code = null,
-    string status = null,
-    string paymentMethod = null,
-    string customerId = null,
-    string orderId = null,
-    DateTime? createdSince = null,
-    DateTime? createdUntil = null)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `page` | `int?` | Query, Optional | Page number |
-| `size` | `int?` | Query, Optional | Page size |
-| `code` | `string` | Query, Optional | Filter for charge's code |
-| `status` | `string` | Query, Optional | Filter for charge's status |
-| `paymentMethod` | `string` | Query, Optional | Filter for charge's payment method |
-| `customerId` | `string` | Query, Optional | Filter for charge's customer id |
-| `orderId` | `string` | Query, Optional | Filter for charge's order id |
-| `createdSince` | `DateTime?` | Query, Optional | Filter for the beginning of the range for charge's creation |
-| `createdUntil` | `DateTime?` | Query, Optional | Filter for the end of the range for charge's creation |
-
-## Response Type
-
-[`Task<Models.ListChargesResponse>`](/doc/models/list-charges-response.md)
-
-## Example Usage
-
-```csharp
-try
-{
-    ListChargesResponse result = await chargesController.GetChargesAsync(null, null, null, null, null, null, null, null, null);
-}
-catch (ApiException e){};
-```
-
-
-# Capture Charge
-
-Captures a charge
-
-```csharp
-CaptureChargeAsync(
-    string chargeId,
-    Models.CreateCaptureChargeRequest request = null,
-    string idempotencyKey = null)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `chargeId` | `string` | Template, Required | Charge id |
-| `request` | [`Models.CreateCaptureChargeRequest`](/doc/models/create-capture-charge-request.md) | Body, Optional | Request for capturing a charge |
-| `idempotencyKey` | `string` | Header, Optional | - |
-
-## Response Type
-
-[`Task<Models.GetChargeResponse>`](/doc/models/get-charge-response.md)
-
-## Example Usage
-
-```csharp
-string chargeId = "charge_id8";
-
-try
-{
-    GetChargeResponse result = await chargesController.CaptureChargeAsync(chargeId, null, null);
-}
-catch (ApiException e){};
-```
-
-
 # Update Charge Card
 
 Updates the card from a charge
@@ -356,38 +203,6 @@ catch (ApiException e){};
 ```
 
 
-# Get Charge
-
-Get a charge from its id
-
-```csharp
-GetChargeAsync(
-    string chargeId)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `chargeId` | `string` | Template, Required | Charge id |
-
-## Response Type
-
-[`Task<Models.GetChargeResponse>`](/doc/models/get-charge-response.md)
-
-## Example Usage
-
-```csharp
-string chargeId = "charge_id8";
-
-try
-{
-    GetChargeResponse result = await chargesController.GetChargeAsync(chargeId);
-}
-catch (ApiException e){};
-```
-
-
 # Get Charges Summary
 
 ```csharp
@@ -417,76 +232,6 @@ string status = "status8";
 try
 {
     GetChargesSummaryResponse result = await chargesController.GetChargesSummaryAsync(status, null, null);
-}
-catch (ApiException e){};
-```
-
-
-# Retry Charge
-
-Retries a charge
-
-```csharp
-RetryChargeAsync(
-    string chargeId,
-    string idempotencyKey = null)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `chargeId` | `string` | Template, Required | Charge id |
-| `idempotencyKey` | `string` | Header, Optional | - |
-
-## Response Type
-
-[`Task<Models.GetChargeResponse>`](/doc/models/get-charge-response.md)
-
-## Example Usage
-
-```csharp
-string chargeId = "charge_id8";
-
-try
-{
-    GetChargeResponse result = await chargesController.RetryChargeAsync(chargeId, null);
-}
-catch (ApiException e){};
-```
-
-
-# Cancel Charge
-
-Cancel a charge
-
-```csharp
-CancelChargeAsync(
-    string chargeId,
-    Models.CreateCancelChargeRequest request = null,
-    string idempotencyKey = null)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `chargeId` | `string` | Template, Required | Charge id |
-| `request` | [`Models.CreateCancelChargeRequest`](/doc/models/create-cancel-charge-request.md) | Body, Optional | Request for cancelling a charge |
-| `idempotencyKey` | `string` | Header, Optional | - |
-
-## Response Type
-
-[`Task<Models.GetChargeResponse>`](/doc/models/get-charge-response.md)
-
-## Example Usage
-
-```csharp
-string chargeId = "charge_id8";
-
-try
-{
-    GetChargeResponse result = await chargesController.CancelChargeAsync(chargeId, null, null);
 }
 catch (ApiException e){};
 ```
@@ -564,6 +309,190 @@ catch (ApiException e){};
 ```
 
 
+# Get Charge Transactions
+
+```csharp
+GetChargeTransactionsAsync(
+    string chargeId,
+    int? page = null,
+    int? size = null)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `chargeId` | `string` | Template, Required | Charge Id |
+| `page` | `int?` | Query, Optional | Page number |
+| `size` | `int?` | Query, Optional | Page size |
+
+## Response Type
+
+[`Task<Models.ListChargeTransactionsResponse>`](/doc/models/list-charge-transactions-response.md)
+
+## Example Usage
+
+```csharp
+string chargeId = "charge_id8";
+
+try
+{
+    ListChargeTransactionsResponse result = await chargesController.GetChargeTransactionsAsync(chargeId, null, null);
+}
+catch (ApiException e){};
+```
+
+
+# Capture Charge
+
+Captures a charge
+
+```csharp
+CaptureChargeAsync(
+    string chargeId,
+    Models.CreateCaptureChargeRequest request = null,
+    string idempotencyKey = null)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `chargeId` | `string` | Template, Required | Charge id |
+| `request` | [`Models.CreateCaptureChargeRequest`](/doc/models/create-capture-charge-request.md) | Body, Optional | Request for capturing a charge |
+| `idempotencyKey` | `string` | Header, Optional | - |
+
+## Response Type
+
+[`Task<Models.GetChargeResponse>`](/doc/models/get-charge-response.md)
+
+## Example Usage
+
+```csharp
+string chargeId = "charge_id8";
+
+try
+{
+    GetChargeResponse result = await chargesController.CaptureChargeAsync(chargeId, null, null);
+}
+catch (ApiException e){};
+```
+
+
+# Get Charge
+
+Get a charge from its id
+
+```csharp
+GetChargeAsync(
+    string chargeId)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `chargeId` | `string` | Template, Required | Charge id |
+
+## Response Type
+
+[`Task<Models.GetChargeResponse>`](/doc/models/get-charge-response.md)
+
+## Example Usage
+
+```csharp
+string chargeId = "charge_id8";
+
+try
+{
+    GetChargeResponse result = await chargesController.GetChargeAsync(chargeId);
+}
+catch (ApiException e){};
+```
+
+
+# Cancel Charge
+
+Cancel a charge
+
+```csharp
+CancelChargeAsync(
+    string chargeId,
+    Models.CreateCancelChargeRequest request = null,
+    string idempotencyKey = null)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `chargeId` | `string` | Template, Required | Charge id |
+| `request` | [`Models.CreateCancelChargeRequest`](/doc/models/create-cancel-charge-request.md) | Body, Optional | Request for cancelling a charge |
+| `idempotencyKey` | `string` | Header, Optional | - |
+
+## Response Type
+
+[`Task<Models.GetChargeResponse>`](/doc/models/get-charge-response.md)
+
+## Example Usage
+
+```csharp
+string chargeId = "charge_id8";
+
+try
+{
+    GetChargeResponse result = await chargesController.CancelChargeAsync(chargeId, null, null);
+}
+catch (ApiException e){};
+```
+
+
+# Get Charges
+
+Lists all charges
+
+```csharp
+GetChargesAsync(
+    int? page = null,
+    int? size = null,
+    string code = null,
+    string status = null,
+    string paymentMethod = null,
+    string customerId = null,
+    string orderId = null,
+    DateTime? createdSince = null,
+    DateTime? createdUntil = null)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `page` | `int?` | Query, Optional | Page number |
+| `size` | `int?` | Query, Optional | Page size |
+| `code` | `string` | Query, Optional | Filter for charge's code |
+| `status` | `string` | Query, Optional | Filter for charge's status |
+| `paymentMethod` | `string` | Query, Optional | Filter for charge's payment method |
+| `customerId` | `string` | Query, Optional | Filter for charge's customer id |
+| `orderId` | `string` | Query, Optional | Filter for charge's order id |
+| `createdSince` | `DateTime?` | Query, Optional | Filter for the beginning of the range for charge's creation |
+| `createdUntil` | `DateTime?` | Query, Optional | Filter for the end of the range for charge's creation |
+
+## Response Type
+
+[`Task<Models.ListChargesResponse>`](/doc/models/list-charges-response.md)
+
+## Example Usage
+
+```csharp
+try
+{
+    ListChargesResponse result = await chargesController.GetChargesAsync(null, null, null, null, null, null, null, null, null);
+}
+catch (ApiException e){};
+```
+
+
 # Confirm Payment
 
 ```csharp
@@ -593,6 +522,77 @@ string chargeId = "charge_id8";
 try
 {
     GetChargeResponse result = await chargesController.ConfirmPaymentAsync(chargeId, null, null);
+}
+catch (ApiException e){};
+```
+
+
+# Update Charge Due Date
+
+Updates the due date from a charge
+
+```csharp
+UpdateChargeDueDateAsync(
+    string chargeId,
+    Models.UpdateChargeDueDateRequest request,
+    string idempotencyKey = null)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `chargeId` | `string` | Template, Required | Charge Id |
+| `request` | [`Models.UpdateChargeDueDateRequest`](/doc/models/update-charge-due-date-request.md) | Body, Required | Request for updating the due date |
+| `idempotencyKey` | `string` | Header, Optional | - |
+
+## Response Type
+
+[`Task<Models.GetChargeResponse>`](/doc/models/get-charge-response.md)
+
+## Example Usage
+
+```csharp
+string chargeId = "charge_id8";
+var request = new UpdateChargeDueDateRequest();
+
+try
+{
+    GetChargeResponse result = await chargesController.UpdateChargeDueDateAsync(chargeId, request, null);
+}
+catch (ApiException e){};
+```
+
+
+# Retry Charge
+
+Retries a charge
+
+```csharp
+RetryChargeAsync(
+    string chargeId,
+    string idempotencyKey = null)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `chargeId` | `string` | Template, Required | Charge id |
+| `idempotencyKey` | `string` | Header, Optional | - |
+
+## Response Type
+
+[`Task<Models.GetChargeResponse>`](/doc/models/get-charge-response.md)
+
+## Example Usage
+
+```csharp
+string chargeId = "charge_id8";
+
+try
+{
+    GetChargeResponse result = await chargesController.RetryChargeAsync(chargeId, null);
 }
 catch (ApiException e){};
 ```

--- a/doc/controllers/customers.md
+++ b/doc/controllers/customers.md
@@ -13,24 +13,24 @@ ICustomersController customersController = client.CustomersController;
 * [Update Card](/doc/controllers/customers.md#update-card)
 * [Update Address](/doc/controllers/customers.md#update-address)
 * [Delete Access Token](/doc/controllers/customers.md#delete-access-token)
-* [Create Customer](/doc/controllers/customers.md#create-customer)
 * [Create Address](/doc/controllers/customers.md#create-address)
-* [Delete Access Tokens](/doc/controllers/customers.md#delete-access-tokens)
-* [Get Address](/doc/controllers/customers.md#get-address)
-* [Delete Address](/doc/controllers/customers.md#delete-address)
+* [Create Customer](/doc/controllers/customers.md#create-customer)
 * [Create Card](/doc/controllers/customers.md#create-card)
-* [Get Customers](/doc/controllers/customers.md#get-customers)
-* [Update Customer](/doc/controllers/customers.md#update-customer)
-* [Create Access Token](/doc/controllers/customers.md#create-access-token)
-* [Get Access Tokens](/doc/controllers/customers.md#get-access-tokens)
 * [Get Cards](/doc/controllers/customers.md#get-cards)
 * [Renew Card](/doc/controllers/customers.md#renew-card)
+* [Get Address](/doc/controllers/customers.md#get-address)
+* [Delete Address](/doc/controllers/customers.md#delete-address)
 * [Get Access Token](/doc/controllers/customers.md#get-access-token)
 * [Update Customer Metadata](/doc/controllers/customers.md#update-customer-metadata)
+* [Get Card](/doc/controllers/customers.md#get-card)
+* [Delete Access Tokens](/doc/controllers/customers.md#delete-access-tokens)
+* [Create Access Token](/doc/controllers/customers.md#create-access-token)
+* [Get Access Tokens](/doc/controllers/customers.md#get-access-tokens)
+* [Get Customers](/doc/controllers/customers.md#get-customers)
+* [Update Customer](/doc/controllers/customers.md#update-customer)
 * [Delete Card](/doc/controllers/customers.md#delete-card)
 * [Get Addresses](/doc/controllers/customers.md#get-addresses)
 * [Get Customer](/doc/controllers/customers.md#get-customer)
-* [Get Card](/doc/controllers/customers.md#get-card)
 
 
 # Update Card
@@ -176,6 +176,55 @@ catch (ApiException e){};
 ```
 
 
+# Create Address
+
+Creates a new address for a customer
+
+```csharp
+CreateAddressAsync(
+    string customerId,
+    Models.CreateAddressRequest request,
+    string idempotencyKey = null)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `customerId` | `string` | Template, Required | Customer Id |
+| `request` | [`Models.CreateAddressRequest`](/doc/models/create-address-request.md) | Body, Required | Request for creating an address |
+| `idempotencyKey` | `string` | Header, Optional | - |
+
+## Response Type
+
+[`Task<Models.GetAddressResponse>`](/doc/models/get-address-response.md)
+
+## Example Usage
+
+```csharp
+string customerId = "customer_id8";
+var request = new CreateAddressRequest();
+request.Street = "street6";
+request.Number = "number4";
+request.ZipCode = "zip_code0";
+request.Neighborhood = "neighborhood2";
+request.City = "city6";
+request.State = "state2";
+request.Country = "country0";
+request.Complement = "complement2";
+request.Metadata = new Dictionary<string, string>();
+request.Metadata.Add("key0", "metadata3");
+request.Line1 = "line_10";
+request.Line2 = "line_24";
+
+try
+{
+    GetAddressResponse result = await customersController.CreateAddressAsync(customerId, request, null);
+}
+catch (ApiException e){};
+```
+
+
 # Create Customer
 
 Creates a new customer
@@ -231,14 +280,14 @@ catch (ApiException e){};
 ```
 
 
-# Create Address
+# Create Card
 
-Creates a new address for a customer
+Creates a new card for a customer
 
 ```csharp
-CreateAddressAsync(
+CreateCardAsync(
     string customerId,
-    Models.CreateAddressRequest request,
+    Models.CreateCardRequest request,
     string idempotencyKey = null)
 ```
 
@@ -246,47 +295,65 @@ CreateAddressAsync(
 
 | Parameter | Type | Tags | Description |
 |  --- | --- | --- | --- |
-| `customerId` | `string` | Template, Required | Customer Id |
-| `request` | [`Models.CreateAddressRequest`](/doc/models/create-address-request.md) | Body, Required | Request for creating an address |
+| `customerId` | `string` | Template, Required | Customer id |
+| `request` | [`Models.CreateCardRequest`](/doc/models/create-card-request.md) | Body, Required | Request for creating a card |
 | `idempotencyKey` | `string` | Header, Optional | - |
 
 ## Response Type
 
-[`Task<Models.GetAddressResponse>`](/doc/models/get-address-response.md)
+[`Task<Models.GetCardResponse>`](/doc/models/get-card-response.md)
 
 ## Example Usage
 
 ```csharp
 string customerId = "customer_id8";
-var request = new CreateAddressRequest();
-request.Street = "street6";
+var request = new CreateCardRequest();
 request.Number = "number4";
-request.ZipCode = "zip_code0";
-request.Neighborhood = "neighborhood2";
-request.City = "city6";
-request.State = "state2";
-request.Country = "country0";
-request.Complement = "complement2";
+request.HolderName = "holder_name2";
+request.ExpMonth = 10;
+request.ExpYear = 30;
+request.Cvv = "cvv4";
+request.BillingAddress = new CreateAddressRequest();
+request.BillingAddress.Street = "street8";
+request.BillingAddress.Number = "number4";
+request.BillingAddress.ZipCode = "zip_code2";
+request.BillingAddress.Neighborhood = "neighborhood4";
+request.BillingAddress.City = "city8";
+request.BillingAddress.State = "state4";
+request.BillingAddress.Country = "country2";
+request.BillingAddress.Complement = "complement6";
+request.BillingAddress.Metadata = new Dictionary<string, string>();
+request.BillingAddress.Metadata.Add("key0", "metadata5");
+request.BillingAddress.Metadata.Add("key1", "metadata6");
+request.BillingAddress.Line1 = "line_18";
+request.BillingAddress.Line2 = "line_26";
+request.Brand = "brand0";
+request.BillingAddressId = "billing_address_id2";
 request.Metadata = new Dictionary<string, string>();
 request.Metadata.Add("key0", "metadata3");
-request.Line1 = "line_10";
-request.Line2 = "line_24";
+request.Type = "credit";
+request.Options = new CreateCardOptionsRequest();
+request.Options.VerifyCard = false;
+request.PrivateLabel = false;
+request.Label = "label6";
 
 try
 {
-    GetAddressResponse result = await customersController.CreateAddressAsync(customerId, request, null);
+    GetCardResponse result = await customersController.CreateCardAsync(customerId, request, null);
 }
 catch (ApiException e){};
 ```
 
 
-# Delete Access Tokens
+# Get Cards
 
-Delete a Customer's access tokens
+Get all cards from a customer
 
 ```csharp
-DeleteAccessTokensAsync(
-    string customerId)
+GetCardsAsync(
+    string customerId,
+    int? page = null,
+    int? size = null)
 ```
 
 ## Parameters
@@ -294,10 +361,12 @@ DeleteAccessTokensAsync(
 | Parameter | Type | Tags | Description |
 |  --- | --- | --- | --- |
 | `customerId` | `string` | Template, Required | Customer Id |
+| `page` | `int?` | Query, Optional | Page number |
+| `size` | `int?` | Query, Optional | Page size |
 
 ## Response Type
 
-[`Task<Models.ListAccessTokensResponse>`](/doc/models/list-access-tokens-response.md)
+[`Task<Models.ListCardsResponse>`](/doc/models/list-cards-response.md)
 
 ## Example Usage
 
@@ -306,7 +375,44 @@ string customerId = "customer_id8";
 
 try
 {
-    ListAccessTokensResponse result = await customersController.DeleteAccessTokensAsync(customerId);
+    ListCardsResponse result = await customersController.GetCardsAsync(customerId, null, null);
+}
+catch (ApiException e){};
+```
+
+
+# Renew Card
+
+Renew a card
+
+```csharp
+RenewCardAsync(
+    string customerId,
+    string cardId,
+    string idempotencyKey = null)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `customerId` | `string` | Template, Required | Customer id |
+| `cardId` | `string` | Template, Required | Card Id |
+| `idempotencyKey` | `string` | Header, Optional | - |
+
+## Response Type
+
+[`Task<Models.GetCardResponse>`](/doc/models/get-card-response.md)
+
+## Example Usage
+
+```csharp
+string customerId = "customer_id8";
+string cardId = "card_id4";
+
+try
+{
+    GetCardResponse result = await customersController.RenewCardAsync(customerId, cardId, null);
 }
 catch (ApiException e){};
 ```
@@ -384,14 +490,49 @@ catch (ApiException e){};
 ```
 
 
-# Create Card
+# Get Access Token
 
-Creates a new card for a customer
+Get a Customer's access token
 
 ```csharp
-CreateCardAsync(
+GetAccessTokenAsync(
     string customerId,
-    Models.CreateCardRequest request,
+    string tokenId)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `customerId` | `string` | Template, Required | Customer Id |
+| `tokenId` | `string` | Template, Required | Token Id |
+
+## Response Type
+
+[`Task<Models.GetAccessTokenResponse>`](/doc/models/get-access-token-response.md)
+
+## Example Usage
+
+```csharp
+string customerId = "customer_id8";
+string tokenId = "token_id6";
+
+try
+{
+    GetAccessTokenResponse result = await customersController.GetAccessTokenAsync(customerId, tokenId);
+}
+catch (ApiException e){};
+```
+
+
+# Update Customer Metadata
+
+Updates the metadata a customer
+
+```csharp
+UpdateCustomerMetadataAsync(
+    string customerId,
+    Models.UpdateMetadataRequest request,
     string idempotencyKey = null)
 ```
 
@@ -399,9 +540,46 @@ CreateCardAsync(
 
 | Parameter | Type | Tags | Description |
 |  --- | --- | --- | --- |
-| `customerId` | `string` | Template, Required | Customer id |
-| `request` | [`Models.CreateCardRequest`](/doc/models/create-card-request.md) | Body, Required | Request for creating a card |
+| `customerId` | `string` | Template, Required | The customer id |
+| `request` | [`Models.UpdateMetadataRequest`](/doc/models/update-metadata-request.md) | Body, Required | Request for updating the customer metadata |
 | `idempotencyKey` | `string` | Header, Optional | - |
+
+## Response Type
+
+[`Task<Models.GetCustomerResponse>`](/doc/models/get-customer-response.md)
+
+## Example Usage
+
+```csharp
+string customerId = "customer_id8";
+var request = new UpdateMetadataRequest();
+request.Metadata = new Dictionary<string, string>();
+request.Metadata.Add("key0", "metadata3");
+
+try
+{
+    GetCustomerResponse result = await customersController.UpdateCustomerMetadataAsync(customerId, request, null);
+}
+catch (ApiException e){};
+```
+
+
+# Get Card
+
+Get a customer's card
+
+```csharp
+GetCardAsync(
+    string customerId,
+    string cardId)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `customerId` | `string` | Template, Required | Customer id |
+| `cardId` | `string` | Template, Required | Card id |
 
 ## Response Type
 
@@ -411,39 +589,116 @@ CreateCardAsync(
 
 ```csharp
 string customerId = "customer_id8";
-var request = new CreateCardRequest();
-request.Number = "number4";
-request.HolderName = "holder_name2";
-request.ExpMonth = 10;
-request.ExpYear = 30;
-request.Cvv = "cvv4";
-request.BillingAddress = new CreateAddressRequest();
-request.BillingAddress.Street = "street8";
-request.BillingAddress.Number = "number4";
-request.BillingAddress.ZipCode = "zip_code2";
-request.BillingAddress.Neighborhood = "neighborhood4";
-request.BillingAddress.City = "city8";
-request.BillingAddress.State = "state4";
-request.BillingAddress.Country = "country2";
-request.BillingAddress.Complement = "complement6";
-request.BillingAddress.Metadata = new Dictionary<string, string>();
-request.BillingAddress.Metadata.Add("key0", "metadata5");
-request.BillingAddress.Metadata.Add("key1", "metadata6");
-request.BillingAddress.Line1 = "line_18";
-request.BillingAddress.Line2 = "line_26";
-request.Brand = "brand0";
-request.BillingAddressId = "billing_address_id2";
-request.Metadata = new Dictionary<string, string>();
-request.Metadata.Add("key0", "metadata3");
-request.Type = "credit";
-request.Options = new CreateCardOptionsRequest();
-request.Options.VerifyCard = false;
-request.PrivateLabel = false;
-request.Label = "label6";
+string cardId = "card_id4";
 
 try
 {
-    GetCardResponse result = await customersController.CreateCardAsync(customerId, request, null);
+    GetCardResponse result = await customersController.GetCardAsync(customerId, cardId);
+}
+catch (ApiException e){};
+```
+
+
+# Delete Access Tokens
+
+Delete a Customer's access tokens
+
+```csharp
+DeleteAccessTokensAsync(
+    string customerId)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `customerId` | `string` | Template, Required | Customer Id |
+
+## Response Type
+
+[`Task<Models.ListAccessTokensResponse>`](/doc/models/list-access-tokens-response.md)
+
+## Example Usage
+
+```csharp
+string customerId = "customer_id8";
+
+try
+{
+    ListAccessTokensResponse result = await customersController.DeleteAccessTokensAsync(customerId);
+}
+catch (ApiException e){};
+```
+
+
+# Create Access Token
+
+Creates a access token for a customer
+
+```csharp
+CreateAccessTokenAsync(
+    string customerId,
+    Models.CreateAccessTokenRequest request,
+    string idempotencyKey = null)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `customerId` | `string` | Template, Required | Customer Id |
+| `request` | [`Models.CreateAccessTokenRequest`](/doc/models/create-access-token-request.md) | Body, Required | Request for creating a access token |
+| `idempotencyKey` | `string` | Header, Optional | - |
+
+## Response Type
+
+[`Task<Models.GetAccessTokenResponse>`](/doc/models/get-access-token-response.md)
+
+## Example Usage
+
+```csharp
+string customerId = "customer_id8";
+var request = new CreateAccessTokenRequest();
+
+try
+{
+    GetAccessTokenResponse result = await customersController.CreateAccessTokenAsync(customerId, request, null);
+}
+catch (ApiException e){};
+```
+
+
+# Get Access Tokens
+
+Get all access tokens from a customer
+
+```csharp
+GetAccessTokensAsync(
+    string customerId,
+    int? page = null,
+    int? size = null)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `customerId` | `string` | Template, Required | Customer Id |
+| `page` | `int?` | Query, Optional | Page number |
+| `size` | `int?` | Query, Optional | Page size |
+
+## Response Type
+
+[`Task<Models.ListAccessTokensResponse>`](/doc/models/list-access-tokens-response.md)
+
+## Example Usage
+
+```csharp
+string customerId = "customer_id8";
+
+try
+{
+    ListAccessTokensResponse result = await customersController.GetAccessTokensAsync(customerId, null, null);
 }
 catch (ApiException e){};
 ```
@@ -524,226 +779,6 @@ var request = new UpdateCustomerRequest();
 try
 {
     GetCustomerResponse result = await customersController.UpdateCustomerAsync(customerId, request, null);
-}
-catch (ApiException e){};
-```
-
-
-# Create Access Token
-
-Creates a access token for a customer
-
-```csharp
-CreateAccessTokenAsync(
-    string customerId,
-    Models.CreateAccessTokenRequest request,
-    string idempotencyKey = null)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `customerId` | `string` | Template, Required | Customer Id |
-| `request` | [`Models.CreateAccessTokenRequest`](/doc/models/create-access-token-request.md) | Body, Required | Request for creating a access token |
-| `idempotencyKey` | `string` | Header, Optional | - |
-
-## Response Type
-
-[`Task<Models.GetAccessTokenResponse>`](/doc/models/get-access-token-response.md)
-
-## Example Usage
-
-```csharp
-string customerId = "customer_id8";
-var request = new CreateAccessTokenRequest();
-
-try
-{
-    GetAccessTokenResponse result = await customersController.CreateAccessTokenAsync(customerId, request, null);
-}
-catch (ApiException e){};
-```
-
-
-# Get Access Tokens
-
-Get all access tokens from a customer
-
-```csharp
-GetAccessTokensAsync(
-    string customerId,
-    int? page = null,
-    int? size = null)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `customerId` | `string` | Template, Required | Customer Id |
-| `page` | `int?` | Query, Optional | Page number |
-| `size` | `int?` | Query, Optional | Page size |
-
-## Response Type
-
-[`Task<Models.ListAccessTokensResponse>`](/doc/models/list-access-tokens-response.md)
-
-## Example Usage
-
-```csharp
-string customerId = "customer_id8";
-
-try
-{
-    ListAccessTokensResponse result = await customersController.GetAccessTokensAsync(customerId, null, null);
-}
-catch (ApiException e){};
-```
-
-
-# Get Cards
-
-Get all cards from a customer
-
-```csharp
-GetCardsAsync(
-    string customerId,
-    int? page = null,
-    int? size = null)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `customerId` | `string` | Template, Required | Customer Id |
-| `page` | `int?` | Query, Optional | Page number |
-| `size` | `int?` | Query, Optional | Page size |
-
-## Response Type
-
-[`Task<Models.ListCardsResponse>`](/doc/models/list-cards-response.md)
-
-## Example Usage
-
-```csharp
-string customerId = "customer_id8";
-
-try
-{
-    ListCardsResponse result = await customersController.GetCardsAsync(customerId, null, null);
-}
-catch (ApiException e){};
-```
-
-
-# Renew Card
-
-Renew a card
-
-```csharp
-RenewCardAsync(
-    string customerId,
-    string cardId,
-    string idempotencyKey = null)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `customerId` | `string` | Template, Required | Customer id |
-| `cardId` | `string` | Template, Required | Card Id |
-| `idempotencyKey` | `string` | Header, Optional | - |
-
-## Response Type
-
-[`Task<Models.GetCardResponse>`](/doc/models/get-card-response.md)
-
-## Example Usage
-
-```csharp
-string customerId = "customer_id8";
-string cardId = "card_id4";
-
-try
-{
-    GetCardResponse result = await customersController.RenewCardAsync(customerId, cardId, null);
-}
-catch (ApiException e){};
-```
-
-
-# Get Access Token
-
-Get a Customer's access token
-
-```csharp
-GetAccessTokenAsync(
-    string customerId,
-    string tokenId)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `customerId` | `string` | Template, Required | Customer Id |
-| `tokenId` | `string` | Template, Required | Token Id |
-
-## Response Type
-
-[`Task<Models.GetAccessTokenResponse>`](/doc/models/get-access-token-response.md)
-
-## Example Usage
-
-```csharp
-string customerId = "customer_id8";
-string tokenId = "token_id6";
-
-try
-{
-    GetAccessTokenResponse result = await customersController.GetAccessTokenAsync(customerId, tokenId);
-}
-catch (ApiException e){};
-```
-
-
-# Update Customer Metadata
-
-Updates the metadata a customer
-
-```csharp
-UpdateCustomerMetadataAsync(
-    string customerId,
-    Models.UpdateMetadataRequest request,
-    string idempotencyKey = null)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `customerId` | `string` | Template, Required | The customer id |
-| `request` | [`Models.UpdateMetadataRequest`](/doc/models/update-metadata-request.md) | Body, Required | Request for updating the customer metadata |
-| `idempotencyKey` | `string` | Header, Optional | - |
-
-## Response Type
-
-[`Task<Models.GetCustomerResponse>`](/doc/models/get-customer-response.md)
-
-## Example Usage
-
-```csharp
-string customerId = "customer_id8";
-var request = new UpdateMetadataRequest();
-request.Metadata = new Dictionary<string, string>();
-request.Metadata.Add("key0", "metadata3");
-
-try
-{
-    GetCustomerResponse result = await customersController.UpdateCustomerMetadataAsync(customerId, request, null);
 }
 catch (ApiException e){};
 ```
@@ -849,41 +884,6 @@ string customerId = "customer_id8";
 try
 {
     GetCustomerResponse result = await customersController.GetCustomerAsync(customerId);
-}
-catch (ApiException e){};
-```
-
-
-# Get Card
-
-Get a customer's card
-
-```csharp
-GetCardAsync(
-    string customerId,
-    string cardId)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `customerId` | `string` | Template, Required | Customer id |
-| `cardId` | `string` | Template, Required | Card id |
-
-## Response Type
-
-[`Task<Models.GetCardResponse>`](/doc/models/get-card-response.md)
-
-## Example Usage
-
-```csharp
-string customerId = "customer_id8";
-string cardId = "card_id4";
-
-try
-{
-    GetCardResponse result = await customersController.GetCardAsync(customerId, cardId);
 }
 catch (ApiException e){};
 ```

--- a/doc/controllers/invoices.md
+++ b/doc/controllers/invoices.md
@@ -10,116 +10,13 @@ IInvoicesController invoicesController = client.InvoicesController;
 
 ## Methods
 
-* [Update Invoice Metadata](/doc/controllers/invoices.md#update-invoice-metadata)
-* [Get Partial Invoice](/doc/controllers/invoices.md#get-partial-invoice)
-* [Cancel Invoice](/doc/controllers/invoices.md#cancel-invoice)
 * [Create Invoice](/doc/controllers/invoices.md#create-invoice)
 * [Get Invoices](/doc/controllers/invoices.md#get-invoices)
-* [Get Invoice](/doc/controllers/invoices.md#get-invoice)
+* [Cancel Invoice](/doc/controllers/invoices.md#cancel-invoice)
+* [Update Invoice Metadata](/doc/controllers/invoices.md#update-invoice-metadata)
+* [Get Partial Invoice](/doc/controllers/invoices.md#get-partial-invoice)
 * [Update Invoice Status](/doc/controllers/invoices.md#update-invoice-status)
-
-
-# Update Invoice Metadata
-
-Updates the metadata from an invoice
-
-```csharp
-UpdateInvoiceMetadataAsync(
-    string invoiceId,
-    Models.UpdateMetadataRequest request,
-    string idempotencyKey = null)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `invoiceId` | `string` | Template, Required | The invoice id |
-| `request` | [`Models.UpdateMetadataRequest`](/doc/models/update-metadata-request.md) | Body, Required | Request for updating the invoice metadata |
-| `idempotencyKey` | `string` | Header, Optional | - |
-
-## Response Type
-
-[`Task<Models.GetInvoiceResponse>`](/doc/models/get-invoice-response.md)
-
-## Example Usage
-
-```csharp
-string invoiceId = "invoice_id0";
-var request = new UpdateMetadataRequest();
-request.Metadata = new Dictionary<string, string>();
-request.Metadata.Add("key0", "metadata3");
-
-try
-{
-    GetInvoiceResponse result = await invoicesController.UpdateInvoiceMetadataAsync(invoiceId, request, null);
-}
-catch (ApiException e){};
-```
-
-
-# Get Partial Invoice
-
-```csharp
-GetPartialInvoiceAsync(
-    string subscriptionId)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `subscriptionId` | `string` | Template, Required | Subscription Id |
-
-## Response Type
-
-[`Task<Models.GetInvoiceResponse>`](/doc/models/get-invoice-response.md)
-
-## Example Usage
-
-```csharp
-string subscriptionId = "subscription_id0";
-
-try
-{
-    GetInvoiceResponse result = await invoicesController.GetPartialInvoiceAsync(subscriptionId);
-}
-catch (ApiException e){};
-```
-
-
-# Cancel Invoice
-
-Cancels an invoice
-
-```csharp
-CancelInvoiceAsync(
-    string invoiceId,
-    string idempotencyKey = null)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `invoiceId` | `string` | Template, Required | Invoice id |
-| `idempotencyKey` | `string` | Header, Optional | - |
-
-## Response Type
-
-[`Task<Models.GetInvoiceResponse>`](/doc/models/get-invoice-response.md)
-
-## Example Usage
-
-```csharp
-string invoiceId = "invoice_id0";
-
-try
-{
-    GetInvoiceResponse result = await invoicesController.CancelInvoiceAsync(invoiceId, null);
-}
-catch (ApiException e){};
-```
+* [Get Invoice](/doc/controllers/invoices.md#get-invoice)
 
 
 # Create Invoice
@@ -211,20 +108,22 @@ catch (ApiException e){};
 ```
 
 
-# Get Invoice
+# Cancel Invoice
 
-Gets an invoice
+Cancels an invoice
 
 ```csharp
-GetInvoiceAsync(
-    string invoiceId)
+CancelInvoiceAsync(
+    string invoiceId,
+    string idempotencyKey = null)
 ```
 
 ## Parameters
 
 | Parameter | Type | Tags | Description |
 |  --- | --- | --- | --- |
-| `invoiceId` | `string` | Template, Required | Invoice Id |
+| `invoiceId` | `string` | Template, Required | Invoice id |
+| `idempotencyKey` | `string` | Header, Optional | - |
 
 ## Response Type
 
@@ -237,7 +136,76 @@ string invoiceId = "invoice_id0";
 
 try
 {
-    GetInvoiceResponse result = await invoicesController.GetInvoiceAsync(invoiceId);
+    GetInvoiceResponse result = await invoicesController.CancelInvoiceAsync(invoiceId, null);
+}
+catch (ApiException e){};
+```
+
+
+# Update Invoice Metadata
+
+Updates the metadata from an invoice
+
+```csharp
+UpdateInvoiceMetadataAsync(
+    string invoiceId,
+    Models.UpdateMetadataRequest request,
+    string idempotencyKey = null)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `invoiceId` | `string` | Template, Required | The invoice id |
+| `request` | [`Models.UpdateMetadataRequest`](/doc/models/update-metadata-request.md) | Body, Required | Request for updating the invoice metadata |
+| `idempotencyKey` | `string` | Header, Optional | - |
+
+## Response Type
+
+[`Task<Models.GetInvoiceResponse>`](/doc/models/get-invoice-response.md)
+
+## Example Usage
+
+```csharp
+string invoiceId = "invoice_id0";
+var request = new UpdateMetadataRequest();
+request.Metadata = new Dictionary<string, string>();
+request.Metadata.Add("key0", "metadata3");
+
+try
+{
+    GetInvoiceResponse result = await invoicesController.UpdateInvoiceMetadataAsync(invoiceId, request, null);
+}
+catch (ApiException e){};
+```
+
+
+# Get Partial Invoice
+
+```csharp
+GetPartialInvoiceAsync(
+    string subscriptionId)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `subscriptionId` | `string` | Template, Required | Subscription Id |
+
+## Response Type
+
+[`Task<Models.GetInvoiceResponse>`](/doc/models/get-invoice-response.md)
+
+## Example Usage
+
+```csharp
+string subscriptionId = "subscription_id0";
+
+try
+{
+    GetInvoiceResponse result = await invoicesController.GetPartialInvoiceAsync(subscriptionId);
 }
 catch (ApiException e){};
 ```
@@ -276,6 +244,38 @@ request.Status = "status8";
 try
 {
     GetInvoiceResponse result = await invoicesController.UpdateInvoiceStatusAsync(invoiceId, request, null);
+}
+catch (ApiException e){};
+```
+
+
+# Get Invoice
+
+Gets an invoice
+
+```csharp
+GetInvoiceAsync(
+    string invoiceId)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `invoiceId` | `string` | Template, Required | Invoice Id |
+
+## Response Type
+
+[`Task<Models.GetInvoiceResponse>`](/doc/models/get-invoice-response.md)
+
+## Example Usage
+
+```csharp
+string invoiceId = "invoice_id0";
+
+try
+{
+    GetInvoiceResponse result = await invoicesController.GetInvoiceAsync(invoiceId);
 }
 catch (ApiException e){};
 ```

--- a/doc/controllers/orders.md
+++ b/doc/controllers/orders.md
@@ -11,15 +11,15 @@ IOrdersController ordersController = client.OrdersController;
 ## Methods
 
 * [Get Orders](/doc/controllers/orders.md#get-orders)
-* [Update Order Item](/doc/controllers/orders.md#update-order-item)
-* [Delete All Order Items](/doc/controllers/orders.md#delete-all-order-items)
-* [Delete Order Item](/doc/controllers/orders.md#delete-order-item)
+* [Get Order Item](/doc/controllers/orders.md#get-order-item)
+* [Get Order](/doc/controllers/orders.md#get-order)
 * [Close Order](/doc/controllers/orders.md#close-order)
 * [Create Order](/doc/controllers/orders.md#create-order)
-* [Create Order Item](/doc/controllers/orders.md#create-order-item)
-* [Get Order Item](/doc/controllers/orders.md#get-order-item)
+* [Update Order Item](/doc/controllers/orders.md#update-order-item)
+* [Delete All Order Items](/doc/controllers/orders.md#delete-all-order-items)
 * [Update Order Metadata](/doc/controllers/orders.md#update-order-metadata)
-* [Get Order](/doc/controllers/orders.md#get-order)
+* [Delete Order Item](/doc/controllers/orders.md#delete-order-item)
+* [Create Order Item](/doc/controllers/orders.md#create-order-item)
 
 
 # Get Orders
@@ -64,14 +64,12 @@ catch (ApiException e){};
 ```
 
 
-# Update Order Item
+# Get Order Item
 
 ```csharp
-UpdateOrderItemAsync(
+GetOrderItemAsync(
     string orderId,
-    string itemId,
-    Models.UpdateOrderItemRequest request,
-    string idempotencyKey = null)
+    string itemId)
 ```
 
 ## Parameters
@@ -80,8 +78,6 @@ UpdateOrderItemAsync(
 |  --- | --- | --- | --- |
 | `orderId` | `string` | Template, Required | Order Id |
 | `itemId` | `string` | Template, Required | Item Id |
-| `request` | [`Models.UpdateOrderItemRequest`](/doc/models/update-order-item-request.md) | Body, Required | Item Model |
-| `idempotencyKey` | `string` | Header, Optional | - |
 
 ## Response Type
 
@@ -92,34 +88,29 @@ UpdateOrderItemAsync(
 ```csharp
 string orderId = "orderId2";
 string itemId = "itemId8";
-var request = new UpdateOrderItemRequest();
-request.Amount = 242;
-request.Description = "description6";
-request.Quantity = 100;
-request.Category = "category4";
 
 try
 {
-    GetOrderItemResponse result = await ordersController.UpdateOrderItemAsync(orderId, itemId, request, null);
+    GetOrderItemResponse result = await ordersController.GetOrderItemAsync(orderId, itemId);
 }
 catch (ApiException e){};
 ```
 
 
-# Delete All Order Items
+# Get Order
+
+Gets an order
 
 ```csharp
-DeleteAllOrderItemsAsync(
-    string orderId,
-    string idempotencyKey = null)
+GetOrderAsync(
+    string orderId)
 ```
 
 ## Parameters
 
 | Parameter | Type | Tags | Description |
 |  --- | --- | --- | --- |
-| `orderId` | `string` | Template, Required | Order Id |
-| `idempotencyKey` | `string` | Header, Optional | - |
+| `orderId` | `string` | Template, Required | Order id |
 
 ## Response Type
 
@@ -128,46 +119,11 @@ DeleteAllOrderItemsAsync(
 ## Example Usage
 
 ```csharp
-string orderId = "orderId2";
+string orderId = "order_id6";
 
 try
 {
-    GetOrderResponse result = await ordersController.DeleteAllOrderItemsAsync(orderId, null);
-}
-catch (ApiException e){};
-```
-
-
-# Delete Order Item
-
-```csharp
-DeleteOrderItemAsync(
-    string orderId,
-    string itemId,
-    string idempotencyKey = null)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `orderId` | `string` | Template, Required | Order Id |
-| `itemId` | `string` | Template, Required | Item Id |
-| `idempotencyKey` | `string` | Header, Optional | - |
-
-## Response Type
-
-[`Task<Models.GetOrderItemResponse>`](/doc/models/get-order-item-response.md)
-
-## Example Usage
-
-```csharp
-string orderId = "orderId2";
-string itemId = "itemId8";
-
-try
-{
-    GetOrderItemResponse result = await ordersController.DeleteOrderItemAsync(orderId, itemId, null);
+    GetOrderResponse result = await ordersController.GetOrderAsync(orderId);
 }
 catch (ApiException e){};
 ```
@@ -308,12 +264,13 @@ catch (ApiException e){};
 ```
 
 
-# Create Order Item
+# Update Order Item
 
 ```csharp
-CreateOrderItemAsync(
+UpdateOrderItemAsync(
     string orderId,
-    Models.CreateOrderItemRequest request,
+    string itemId,
+    Models.UpdateOrderItemRequest request,
     string idempotencyKey = null)
 ```
 
@@ -322,7 +279,8 @@ CreateOrderItemAsync(
 | Parameter | Type | Tags | Description |
 |  --- | --- | --- | --- |
 | `orderId` | `string` | Template, Required | Order Id |
-| `request` | [`Models.CreateOrderItemRequest`](/doc/models/create-order-item-request.md) | Body, Required | Order Item Model |
+| `itemId` | `string` | Template, Required | Item Id |
+| `request` | [`Models.UpdateOrderItemRequest`](/doc/models/update-order-item-request.md) | Body, Required | Item Model |
 | `idempotencyKey` | `string` | Header, Optional | - |
 
 ## Response Type
@@ -333,7 +291,8 @@ CreateOrderItemAsync(
 
 ```csharp
 string orderId = "orderId2";
-var request = new CreateOrderItemRequest();
+string itemId = "itemId8";
+var request = new UpdateOrderItemRequest();
 request.Amount = 242;
 request.Description = "description6";
 request.Quantity = 100;
@@ -341,18 +300,18 @@ request.Category = "category4";
 
 try
 {
-    GetOrderItemResponse result = await ordersController.CreateOrderItemAsync(orderId, request, null);
+    GetOrderItemResponse result = await ordersController.UpdateOrderItemAsync(orderId, itemId, request, null);
 }
 catch (ApiException e){};
 ```
 
 
-# Get Order Item
+# Delete All Order Items
 
 ```csharp
-GetOrderItemAsync(
+DeleteAllOrderItemsAsync(
     string orderId,
-    string itemId)
+    string idempotencyKey = null)
 ```
 
 ## Parameters
@@ -360,21 +319,20 @@ GetOrderItemAsync(
 | Parameter | Type | Tags | Description |
 |  --- | --- | --- | --- |
 | `orderId` | `string` | Template, Required | Order Id |
-| `itemId` | `string` | Template, Required | Item Id |
+| `idempotencyKey` | `string` | Header, Optional | - |
 
 ## Response Type
 
-[`Task<Models.GetOrderItemResponse>`](/doc/models/get-order-item-response.md)
+[`Task<Models.GetOrderResponse>`](/doc/models/get-order-response.md)
 
 ## Example Usage
 
 ```csharp
 string orderId = "orderId2";
-string itemId = "itemId8";
 
 try
 {
-    GetOrderItemResponse result = await ordersController.GetOrderItemAsync(orderId, itemId);
+    GetOrderResponse result = await ordersController.DeleteAllOrderItemsAsync(orderId, null);
 }
 catch (ApiException e){};
 ```
@@ -419,33 +377,75 @@ catch (ApiException e){};
 ```
 
 
-# Get Order
-
-Gets an order
+# Delete Order Item
 
 ```csharp
-GetOrderAsync(
-    string orderId)
+DeleteOrderItemAsync(
+    string orderId,
+    string itemId,
+    string idempotencyKey = null)
 ```
 
 ## Parameters
 
 | Parameter | Type | Tags | Description |
 |  --- | --- | --- | --- |
-| `orderId` | `string` | Template, Required | Order id |
+| `orderId` | `string` | Template, Required | Order Id |
+| `itemId` | `string` | Template, Required | Item Id |
+| `idempotencyKey` | `string` | Header, Optional | - |
 
 ## Response Type
 
-[`Task<Models.GetOrderResponse>`](/doc/models/get-order-response.md)
+[`Task<Models.GetOrderItemResponse>`](/doc/models/get-order-item-response.md)
 
 ## Example Usage
 
 ```csharp
-string orderId = "order_id6";
+string orderId = "orderId2";
+string itemId = "itemId8";
 
 try
 {
-    GetOrderResponse result = await ordersController.GetOrderAsync(orderId);
+    GetOrderItemResponse result = await ordersController.DeleteOrderItemAsync(orderId, itemId, null);
+}
+catch (ApiException e){};
+```
+
+
+# Create Order Item
+
+```csharp
+CreateOrderItemAsync(
+    string orderId,
+    Models.CreateOrderItemRequest request,
+    string idempotencyKey = null)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `orderId` | `string` | Template, Required | Order Id |
+| `request` | [`Models.CreateOrderItemRequest`](/doc/models/create-order-item-request.md) | Body, Required | Order Item Model |
+| `idempotencyKey` | `string` | Header, Optional | - |
+
+## Response Type
+
+[`Task<Models.GetOrderItemResponse>`](/doc/models/get-order-item-response.md)
+
+## Example Usage
+
+```csharp
+string orderId = "orderId2";
+var request = new CreateOrderItemRequest();
+request.Amount = 242;
+request.Description = "description6";
+request.Quantity = 100;
+request.Category = "category4";
+
+try
+{
+    GetOrderItemResponse result = await ordersController.CreateOrderItemAsync(orderId, request, null);
 }
 catch (ApiException e){};
 ```

--- a/doc/controllers/plans.md
+++ b/doc/controllers/plans.md
@@ -11,15 +11,15 @@ IPlansController plansController = client.PlansController;
 ## Methods
 
 * [Get Plan](/doc/controllers/plans.md#get-plan)
-* [Delete Plan](/doc/controllers/plans.md#delete-plan)
+* [Update Plan](/doc/controllers/plans.md#update-plan)
 * [Update Plan Metadata](/doc/controllers/plans.md#update-plan-metadata)
-* [Update Plan Item](/doc/controllers/plans.md#update-plan-item)
-* [Create Plan Item](/doc/controllers/plans.md#create-plan-item)
-* [Get Plan Item](/doc/controllers/plans.md#get-plan-item)
-* [Create Plan](/doc/controllers/plans.md#create-plan)
 * [Delete Plan Item](/doc/controllers/plans.md#delete-plan-item)
 * [Get Plans](/doc/controllers/plans.md#get-plans)
-* [Update Plan](/doc/controllers/plans.md#update-plan)
+* [Get Plan Item](/doc/controllers/plans.md#get-plan-item)
+* [Delete Plan](/doc/controllers/plans.md#delete-plan)
+* [Update Plan Item](/doc/controllers/plans.md#update-plan-item)
+* [Create Plan Item](/doc/controllers/plans.md#create-plan-item)
+* [Create Plan](/doc/controllers/plans.md#create-plan)
 
 
 # Get Plan
@@ -54,13 +54,14 @@ catch (ApiException e){};
 ```
 
 
-# Delete Plan
+# Update Plan
 
-Deletes a plan
+Updates a plan
 
 ```csharp
-DeletePlanAsync(
+UpdatePlanAsync(
     string planId,
+    Models.UpdatePlanRequest request,
     string idempotencyKey = null)
 ```
 
@@ -69,6 +70,7 @@ DeletePlanAsync(
 | Parameter | Type | Tags | Description |
 |  --- | --- | --- | --- |
 | `planId` | `string` | Template, Required | Plan id |
+| `request` | [`Models.UpdatePlanRequest`](/doc/models/update-plan-request.md) | Body, Required | Request for updating a plan |
 | `idempotencyKey` | `string` | Header, Optional | - |
 
 ## Response Type
@@ -79,10 +81,31 @@ DeletePlanAsync(
 
 ```csharp
 string planId = "plan_id8";
+var request = new UpdatePlanRequest();
+request.Name = "name6";
+request.Description = "description6";
+request.Installments = new List<int>();
+request.Installments.Add(151);
+request.Installments.Add(152);
+request.StatementDescriptor = "statement_descriptor6";
+request.Currency = "currency6";
+request.Interval = "interval4";
+request.IntervalCount = 114;
+request.PaymentMethods = new List<string>();
+request.PaymentMethods.Add("payment_methods1");
+request.PaymentMethods.Add("payment_methods0");
+request.PaymentMethods.Add("payment_methods9");
+request.BillingType = "billing_type0";
+request.Status = "status8";
+request.Shippable = false;
+request.BillingDays = new List<int>();
+request.BillingDays.Add(115);
+request.Metadata = new Dictionary<string, string>();
+request.Metadata.Add("key0", "metadata3");
 
 try
 {
-    GetPlanResponse result = await plansController.DeletePlanAsync(planId, null);
+    GetPlanResponse result = await plansController.UpdatePlanAsync(planId, request, null);
 }
 catch (ApiException e){};
 ```
@@ -122,6 +145,154 @@ request.Metadata.Add("key0", "metadata3");
 try
 {
     GetPlanResponse result = await plansController.UpdatePlanMetadataAsync(planId, request, null);
+}
+catch (ApiException e){};
+```
+
+
+# Delete Plan Item
+
+Removes an item from a plan
+
+```csharp
+DeletePlanItemAsync(
+    string planId,
+    string planItemId,
+    string idempotencyKey = null)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `planId` | `string` | Template, Required | Plan id |
+| `planItemId` | `string` | Template, Required | Plan item id |
+| `idempotencyKey` | `string` | Header, Optional | - |
+
+## Response Type
+
+[`Task<Models.GetPlanItemResponse>`](/doc/models/get-plan-item-response.md)
+
+## Example Usage
+
+```csharp
+string planId = "plan_id8";
+string planItemId = "plan_item_id0";
+
+try
+{
+    GetPlanItemResponse result = await plansController.DeletePlanItemAsync(planId, planItemId, null);
+}
+catch (ApiException e){};
+```
+
+
+# Get Plans
+
+Gets all plans
+
+```csharp
+GetPlansAsync(
+    int? page = null,
+    int? size = null,
+    string name = null,
+    string status = null,
+    string billingType = null,
+    DateTime? createdSince = null,
+    DateTime? createdUntil = null)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `page` | `int?` | Query, Optional | Page number |
+| `size` | `int?` | Query, Optional | Page size |
+| `name` | `string` | Query, Optional | Filter for Plan's name |
+| `status` | `string` | Query, Optional | Filter for Plan's status |
+| `billingType` | `string` | Query, Optional | Filter for plan's billing type |
+| `createdSince` | `DateTime?` | Query, Optional | Filter for plan's creation date start range |
+| `createdUntil` | `DateTime?` | Query, Optional | Filter for plan's creation date end range |
+
+## Response Type
+
+[`Task<Models.ListPlansResponse>`](/doc/models/list-plans-response.md)
+
+## Example Usage
+
+```csharp
+try
+{
+    ListPlansResponse result = await plansController.GetPlansAsync(null, null, null, null, null, null, null);
+}
+catch (ApiException e){};
+```
+
+
+# Get Plan Item
+
+Gets a plan item
+
+```csharp
+GetPlanItemAsync(
+    string planId,
+    string planItemId)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `planId` | `string` | Template, Required | Plan id |
+| `planItemId` | `string` | Template, Required | Plan item id |
+
+## Response Type
+
+[`Task<Models.GetPlanItemResponse>`](/doc/models/get-plan-item-response.md)
+
+## Example Usage
+
+```csharp
+string planId = "plan_id8";
+string planItemId = "plan_item_id0";
+
+try
+{
+    GetPlanItemResponse result = await plansController.GetPlanItemAsync(planId, planItemId);
+}
+catch (ApiException e){};
+```
+
+
+# Delete Plan
+
+Deletes a plan
+
+```csharp
+DeletePlanAsync(
+    string planId,
+    string idempotencyKey = null)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `planId` | `string` | Template, Required | Plan id |
+| `idempotencyKey` | `string` | Header, Optional | - |
+
+## Response Type
+
+[`Task<Models.GetPlanResponse>`](/doc/models/get-plan-response.md)
+
+## Example Usage
+
+```csharp
+string planId = "plan_id8";
+
+try
+{
+    GetPlanResponse result = await plansController.DeletePlanAsync(planId, null);
 }
 catch (ApiException e){};
 ```
@@ -228,41 +399,6 @@ request.Description = "description6";
 try
 {
     GetPlanItemResponse result = await plansController.CreatePlanItemAsync(planId, request, null);
-}
-catch (ApiException e){};
-```
-
-
-# Get Plan Item
-
-Gets a plan item
-
-```csharp
-GetPlanItemAsync(
-    string planId,
-    string planItemId)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `planId` | `string` | Template, Required | Plan id |
-| `planItemId` | `string` | Template, Required | Plan item id |
-
-## Response Type
-
-[`Task<Models.GetPlanItemResponse>`](/doc/models/get-plan-item-response.md)
-
-## Example Usage
-
-```csharp
-string planId = "plan_id8";
-string planItemId = "plan_item_id0";
-
-try
-{
-    GetPlanItemResponse result = await plansController.GetPlanItemAsync(planId, planItemId);
 }
 catch (ApiException e){};
 ```
@@ -391,142 +527,6 @@ body.Metadata.Add("key1", "metadata8");
 try
 {
     GetPlanResponse result = await plansController.CreatePlanAsync(body, null);
-}
-catch (ApiException e){};
-```
-
-
-# Delete Plan Item
-
-Removes an item from a plan
-
-```csharp
-DeletePlanItemAsync(
-    string planId,
-    string planItemId,
-    string idempotencyKey = null)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `planId` | `string` | Template, Required | Plan id |
-| `planItemId` | `string` | Template, Required | Plan item id |
-| `idempotencyKey` | `string` | Header, Optional | - |
-
-## Response Type
-
-[`Task<Models.GetPlanItemResponse>`](/doc/models/get-plan-item-response.md)
-
-## Example Usage
-
-```csharp
-string planId = "plan_id8";
-string planItemId = "plan_item_id0";
-
-try
-{
-    GetPlanItemResponse result = await plansController.DeletePlanItemAsync(planId, planItemId, null);
-}
-catch (ApiException e){};
-```
-
-
-# Get Plans
-
-Gets all plans
-
-```csharp
-GetPlansAsync(
-    int? page = null,
-    int? size = null,
-    string name = null,
-    string status = null,
-    string billingType = null,
-    DateTime? createdSince = null,
-    DateTime? createdUntil = null)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `page` | `int?` | Query, Optional | Page number |
-| `size` | `int?` | Query, Optional | Page size |
-| `name` | `string` | Query, Optional | Filter for Plan's name |
-| `status` | `string` | Query, Optional | Filter for Plan's status |
-| `billingType` | `string` | Query, Optional | Filter for plan's billing type |
-| `createdSince` | `DateTime?` | Query, Optional | Filter for plan's creation date start range |
-| `createdUntil` | `DateTime?` | Query, Optional | Filter for plan's creation date end range |
-
-## Response Type
-
-[`Task<Models.ListPlansResponse>`](/doc/models/list-plans-response.md)
-
-## Example Usage
-
-```csharp
-try
-{
-    ListPlansResponse result = await plansController.GetPlansAsync(null, null, null, null, null, null, null);
-}
-catch (ApiException e){};
-```
-
-
-# Update Plan
-
-Updates a plan
-
-```csharp
-UpdatePlanAsync(
-    string planId,
-    Models.UpdatePlanRequest request,
-    string idempotencyKey = null)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `planId` | `string` | Template, Required | Plan id |
-| `request` | [`Models.UpdatePlanRequest`](/doc/models/update-plan-request.md) | Body, Required | Request for updating a plan |
-| `idempotencyKey` | `string` | Header, Optional | - |
-
-## Response Type
-
-[`Task<Models.GetPlanResponse>`](/doc/models/get-plan-response.md)
-
-## Example Usage
-
-```csharp
-string planId = "plan_id8";
-var request = new UpdatePlanRequest();
-request.Name = "name6";
-request.Description = "description6";
-request.Installments = new List<int>();
-request.Installments.Add(151);
-request.Installments.Add(152);
-request.StatementDescriptor = "statement_descriptor6";
-request.Currency = "currency6";
-request.Interval = "interval4";
-request.IntervalCount = 114;
-request.PaymentMethods = new List<string>();
-request.PaymentMethods.Add("payment_methods1");
-request.PaymentMethods.Add("payment_methods0");
-request.PaymentMethods.Add("payment_methods9");
-request.BillingType = "billing_type0";
-request.Status = "status8";
-request.Shippable = false;
-request.BillingDays = new List<int>();
-request.BillingDays.Add(115);
-request.Metadata = new Dictionary<string, string>();
-request.Metadata.Add("key0", "metadata3");
-
-try
-{
-    GetPlanResponse result = await plansController.UpdatePlanAsync(planId, request, null);
 }
 catch (ApiException e){};
 ```

--- a/doc/controllers/recipients.md
+++ b/doc/controllers/recipients.md
@@ -14,21 +14,21 @@ IRecipientsController recipientsController = client.RecipientsController;
 * [Create Anticipation](/doc/controllers/recipients.md#create-anticipation)
 * [Get Anticipation Limits](/doc/controllers/recipients.md#get-anticipation-limits)
 * [Get Recipients](/doc/controllers/recipients.md#get-recipients)
-* [Get Withdraw by Id](/doc/controllers/recipients.md#get-withdraw-by-id)
-* [Update Recipient Default Bank Account](/doc/controllers/recipients.md#update-recipient-default-bank-account)
 * [Update Recipient Metadata](/doc/controllers/recipients.md#update-recipient-metadata)
-* [Get Transfers](/doc/controllers/recipients.md#get-transfers)
 * [Get Transfer](/doc/controllers/recipients.md#get-transfer)
-* [Create Withdraw](/doc/controllers/recipients.md#create-withdraw)
-* [Update Automatic Anticipation Settings](/doc/controllers/recipients.md#update-automatic-anticipation-settings)
 * [Get Anticipation](/doc/controllers/recipients.md#get-anticipation)
 * [Update Recipient Transfer Settings](/doc/controllers/recipients.md#update-recipient-transfer-settings)
 * [Get Anticipations](/doc/controllers/recipients.md#get-anticipations)
-* [Get Recipient](/doc/controllers/recipients.md#get-recipient)
+* [Update Recipient Default Bank Account](/doc/controllers/recipients.md#update-recipient-default-bank-account)
+* [Create Withdraw](/doc/controllers/recipients.md#create-withdraw)
 * [Get Balance](/doc/controllers/recipients.md#get-balance)
-* [Get Withdrawals](/doc/controllers/recipients.md#get-withdrawals)
 * [Create Transfer](/doc/controllers/recipients.md#create-transfer)
 * [Create Recipient](/doc/controllers/recipients.md#create-recipient)
+* [Update Automatic Anticipation Settings](/doc/controllers/recipients.md#update-automatic-anticipation-settings)
+* [Get Recipient](/doc/controllers/recipients.md#get-recipient)
+* [Get Withdrawals](/doc/controllers/recipients.md#get-withdrawals)
+* [Get Withdraw by Id](/doc/controllers/recipients.md#get-withdraw-by-id)
+* [Get Transfers](/doc/controllers/recipients.md#get-transfers)
 * [Get Recipient by Code](/doc/controllers/recipients.md#get-recipient-by-code)
 * [Get Default Recipient](/doc/controllers/recipients.md#get-default-recipient)
 
@@ -187,91 +187,6 @@ catch (ApiException e){};
 ```
 
 
-# Get Withdraw by Id
-
-```csharp
-GetWithdrawByIdAsync(
-    string recipientId,
-    string withdrawalId)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `recipientId` | `string` | Template, Required | - |
-| `withdrawalId` | `string` | Template, Required | - |
-
-## Response Type
-
-[`Task<Models.GetWithdrawResponse>`](/doc/models/get-withdraw-response.md)
-
-## Example Usage
-
-```csharp
-string recipientId = "recipient_id0";
-string withdrawalId = "withdrawal_id2";
-
-try
-{
-    GetWithdrawResponse result = await recipientsController.GetWithdrawByIdAsync(recipientId, withdrawalId);
-}
-catch (ApiException e){};
-```
-
-
-# Update Recipient Default Bank Account
-
-Updates the default bank account from a recipient
-
-```csharp
-UpdateRecipientDefaultBankAccountAsync(
-    string recipientId,
-    Models.UpdateRecipientBankAccountRequest request,
-    string idempotencyKey = null)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `recipientId` | `string` | Template, Required | Recipient id |
-| `request` | [`Models.UpdateRecipientBankAccountRequest`](/doc/models/update-recipient-bank-account-request.md) | Body, Required | Bank account data |
-| `idempotencyKey` | `string` | Header, Optional | - |
-
-## Response Type
-
-[`Task<Models.GetRecipientResponse>`](/doc/models/get-recipient-response.md)
-
-## Example Usage
-
-```csharp
-string recipientId = "recipient_id0";
-var request = new UpdateRecipientBankAccountRequest();
-request.BankAccount = new CreateBankAccountRequest();
-request.BankAccount.HolderName = "holder_name6";
-request.BankAccount.HolderType = "holder_type2";
-request.BankAccount.HolderDocument = "holder_document4";
-request.BankAccount.Bank = "bank8";
-request.BankAccount.BranchNumber = "branch_number6";
-request.BankAccount.BranchCheckDigit = "branch_check_digit6";
-request.BankAccount.AccountNumber = "account_number0";
-request.BankAccount.AccountCheckDigit = "account_check_digit6";
-request.BankAccount.Type = "type0";
-request.BankAccount.Metadata = new Dictionary<string, string>();
-request.BankAccount.Metadata.Add("key0", "metadata9");
-request.BankAccount.Metadata.Add("key1", "metadata8");
-request.BankAccount.PixKey = "pix_key4";
-request.PaymentMode = "bank_transfer";
-
-try
-{
-    GetRecipientResponse result = await recipientsController.UpdateRecipientDefaultBankAccountAsync(recipientId, request, null);
-}
-catch (ApiException e){};
-```
-
-
 # Update Recipient Metadata
 
 Updates recipient metadata
@@ -311,48 +226,6 @@ catch (ApiException e){};
 ```
 
 
-# Get Transfers
-
-Gets a paginated list of transfers for the recipient
-
-```csharp
-GetTransfersAsync(
-    string recipientId,
-    int? page = null,
-    int? size = null,
-    string status = null,
-    DateTime? createdSince = null,
-    DateTime? createdUntil = null)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `recipientId` | `string` | Template, Required | Recipient id |
-| `page` | `int?` | Query, Optional | Page number |
-| `size` | `int?` | Query, Optional | Page size |
-| `status` | `string` | Query, Optional | Filter for transfer status |
-| `createdSince` | `DateTime?` | Query, Optional | Filter for start range of transfer creation date |
-| `createdUntil` | `DateTime?` | Query, Optional | Filter for end range of transfer creation date |
-
-## Response Type
-
-[`Task<Models.ListTransferResponse>`](/doc/models/list-transfer-response.md)
-
-## Example Usage
-
-```csharp
-string recipientId = "recipient_id0";
-
-try
-{
-    ListTransferResponse result = await recipientsController.GetTransfersAsync(recipientId, null, null, null, null, null);
-}
-catch (ApiException e){};
-```
-
-
 # Get Transfer
 
 Gets a transfer
@@ -383,77 +256,6 @@ string transferId = "transfer_id6";
 try
 {
     GetTransferResponse result = await recipientsController.GetTransferAsync(recipientId, transferId);
-}
-catch (ApiException e){};
-```
-
-
-# Create Withdraw
-
-```csharp
-CreateWithdrawAsync(
-    string recipientId,
-    Models.CreateWithdrawRequest request)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `recipientId` | `string` | Template, Required | - |
-| `request` | [`Models.CreateWithdrawRequest`](/doc/models/create-withdraw-request.md) | Body, Required | - |
-
-## Response Type
-
-[`Task<Models.GetWithdrawResponse>`](/doc/models/get-withdraw-response.md)
-
-## Example Usage
-
-```csharp
-string recipientId = "recipient_id0";
-var request = new CreateWithdrawRequest();
-request.Amount = 242;
-
-try
-{
-    GetWithdrawResponse result = await recipientsController.CreateWithdrawAsync(recipientId, request);
-}
-catch (ApiException e){};
-```
-
-
-# Update Automatic Anticipation Settings
-
-Updates recipient metadata
-
-```csharp
-UpdateAutomaticAnticipationSettingsAsync(
-    string recipientId,
-    Models.UpdateAutomaticAnticipationSettingsRequest request,
-    string idempotencyKey = null)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `recipientId` | `string` | Template, Required | Recipient id |
-| `request` | [`Models.UpdateAutomaticAnticipationSettingsRequest`](/doc/models/update-automatic-anticipation-settings-request.md) | Body, Required | Metadata |
-| `idempotencyKey` | `string` | Header, Optional | - |
-
-## Response Type
-
-[`Task<Models.GetRecipientResponse>`](/doc/models/get-recipient-response.md)
-
-## Example Usage
-
-```csharp
-string recipientId = "recipient_id0";
-var request = new UpdateAutomaticAnticipationSettingsRequest();
-
-try
-{
-    GetRecipientResponse result = await recipientsController.UpdateAutomaticAnticipationSettingsAsync(recipientId, request, null);
 }
 catch (ApiException e){};
 ```
@@ -580,20 +382,24 @@ catch (ApiException e){};
 ```
 
 
-# Get Recipient
+# Update Recipient Default Bank Account
 
-Retrieves recipient information
+Updates the default bank account from a recipient
 
 ```csharp
-GetRecipientAsync(
-    string recipientId)
+UpdateRecipientDefaultBankAccountAsync(
+    string recipientId,
+    Models.UpdateRecipientBankAccountRequest request,
+    string idempotencyKey = null)
 ```
 
 ## Parameters
 
 | Parameter | Type | Tags | Description |
 |  --- | --- | --- | --- |
-| `recipientId` | `string` | Template, Required | Recipiend id |
+| `recipientId` | `string` | Template, Required | Recipient id |
+| `request` | [`Models.UpdateRecipientBankAccountRequest`](/doc/models/update-recipient-bank-account-request.md) | Body, Required | Bank account data |
+| `idempotencyKey` | `string` | Header, Optional | - |
 
 ## Response Type
 
@@ -603,10 +409,60 @@ GetRecipientAsync(
 
 ```csharp
 string recipientId = "recipient_id0";
+var request = new UpdateRecipientBankAccountRequest();
+request.BankAccount = new CreateBankAccountRequest();
+request.BankAccount.HolderName = "holder_name6";
+request.BankAccount.HolderType = "holder_type2";
+request.BankAccount.HolderDocument = "holder_document4";
+request.BankAccount.Bank = "bank8";
+request.BankAccount.BranchNumber = "branch_number6";
+request.BankAccount.BranchCheckDigit = "branch_check_digit6";
+request.BankAccount.AccountNumber = "account_number0";
+request.BankAccount.AccountCheckDigit = "account_check_digit6";
+request.BankAccount.Type = "type0";
+request.BankAccount.Metadata = new Dictionary<string, string>();
+request.BankAccount.Metadata.Add("key0", "metadata9");
+request.BankAccount.Metadata.Add("key1", "metadata8");
+request.BankAccount.PixKey = "pix_key4";
+request.PaymentMode = "bank_transfer";
 
 try
 {
-    GetRecipientResponse result = await recipientsController.GetRecipientAsync(recipientId);
+    GetRecipientResponse result = await recipientsController.UpdateRecipientDefaultBankAccountAsync(recipientId, request, null);
+}
+catch (ApiException e){};
+```
+
+
+# Create Withdraw
+
+```csharp
+CreateWithdrawAsync(
+    string recipientId,
+    Models.CreateWithdrawRequest request)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `recipientId` | `string` | Template, Required | - |
+| `request` | [`Models.CreateWithdrawRequest`](/doc/models/create-withdraw-request.md) | Body, Required | - |
+
+## Response Type
+
+[`Task<Models.GetWithdrawResponse>`](/doc/models/get-withdraw-response.md)
+
+## Example Usage
+
+```csharp
+string recipientId = "recipient_id0";
+var request = new CreateWithdrawRequest();
+request.Amount = 242;
+
+try
+{
+    GetWithdrawResponse result = await recipientsController.CreateWithdrawAsync(recipientId, request);
 }
 catch (ApiException e){};
 ```
@@ -639,48 +495,6 @@ string recipientId = "recipient_id0";
 try
 {
     GetBalanceResponse result = await recipientsController.GetBalanceAsync(recipientId);
-}
-catch (ApiException e){};
-```
-
-
-# Get Withdrawals
-
-Gets a paginated list of transfers for the recipient
-
-```csharp
-GetWithdrawalsAsync(
-    string recipientId,
-    int? page = null,
-    int? size = null,
-    string status = null,
-    DateTime? createdSince = null,
-    DateTime? createdUntil = null)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `recipientId` | `string` | Template, Required | - |
-| `page` | `int?` | Query, Optional | - |
-| `size` | `int?` | Query, Optional | - |
-| `status` | `string` | Query, Optional | - |
-| `createdSince` | `DateTime?` | Query, Optional | - |
-| `createdUntil` | `DateTime?` | Query, Optional | - |
-
-## Response Type
-
-[`Task<Models.ListWithdrawals>`](/doc/models/list-withdrawals.md)
-
-## Example Usage
-
-```csharp
-string recipientId = "recipient_id0";
-
-try
-{
-    ListWithdrawals result = await recipientsController.GetWithdrawalsAsync(recipientId, null, null, null, null, null);
 }
 catch (ApiException e){};
 ```
@@ -777,6 +591,192 @@ request.PaymentMode = "bank_transfer";
 try
 {
     GetRecipientResponse result = await recipientsController.CreateRecipientAsync(request, null);
+}
+catch (ApiException e){};
+```
+
+
+# Update Automatic Anticipation Settings
+
+Updates recipient metadata
+
+```csharp
+UpdateAutomaticAnticipationSettingsAsync(
+    string recipientId,
+    Models.UpdateAutomaticAnticipationSettingsRequest request,
+    string idempotencyKey = null)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `recipientId` | `string` | Template, Required | Recipient id |
+| `request` | [`Models.UpdateAutomaticAnticipationSettingsRequest`](/doc/models/update-automatic-anticipation-settings-request.md) | Body, Required | Metadata |
+| `idempotencyKey` | `string` | Header, Optional | - |
+
+## Response Type
+
+[`Task<Models.GetRecipientResponse>`](/doc/models/get-recipient-response.md)
+
+## Example Usage
+
+```csharp
+string recipientId = "recipient_id0";
+var request = new UpdateAutomaticAnticipationSettingsRequest();
+
+try
+{
+    GetRecipientResponse result = await recipientsController.UpdateAutomaticAnticipationSettingsAsync(recipientId, request, null);
+}
+catch (ApiException e){};
+```
+
+
+# Get Recipient
+
+Retrieves recipient information
+
+```csharp
+GetRecipientAsync(
+    string recipientId)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `recipientId` | `string` | Template, Required | Recipiend id |
+
+## Response Type
+
+[`Task<Models.GetRecipientResponse>`](/doc/models/get-recipient-response.md)
+
+## Example Usage
+
+```csharp
+string recipientId = "recipient_id0";
+
+try
+{
+    GetRecipientResponse result = await recipientsController.GetRecipientAsync(recipientId);
+}
+catch (ApiException e){};
+```
+
+
+# Get Withdrawals
+
+Gets a paginated list of transfers for the recipient
+
+```csharp
+GetWithdrawalsAsync(
+    string recipientId,
+    int? page = null,
+    int? size = null,
+    string status = null,
+    DateTime? createdSince = null,
+    DateTime? createdUntil = null)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `recipientId` | `string` | Template, Required | - |
+| `page` | `int?` | Query, Optional | - |
+| `size` | `int?` | Query, Optional | - |
+| `status` | `string` | Query, Optional | - |
+| `createdSince` | `DateTime?` | Query, Optional | - |
+| `createdUntil` | `DateTime?` | Query, Optional | - |
+
+## Response Type
+
+[`Task<Models.ListWithdrawals>`](/doc/models/list-withdrawals.md)
+
+## Example Usage
+
+```csharp
+string recipientId = "recipient_id0";
+
+try
+{
+    ListWithdrawals result = await recipientsController.GetWithdrawalsAsync(recipientId, null, null, null, null, null);
+}
+catch (ApiException e){};
+```
+
+
+# Get Withdraw by Id
+
+```csharp
+GetWithdrawByIdAsync(
+    string recipientId,
+    string withdrawalId)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `recipientId` | `string` | Template, Required | - |
+| `withdrawalId` | `string` | Template, Required | - |
+
+## Response Type
+
+[`Task<Models.GetWithdrawResponse>`](/doc/models/get-withdraw-response.md)
+
+## Example Usage
+
+```csharp
+string recipientId = "recipient_id0";
+string withdrawalId = "withdrawal_id2";
+
+try
+{
+    GetWithdrawResponse result = await recipientsController.GetWithdrawByIdAsync(recipientId, withdrawalId);
+}
+catch (ApiException e){};
+```
+
+
+# Get Transfers
+
+Gets a paginated list of transfers for the recipient
+
+```csharp
+GetTransfersAsync(
+    string recipientId,
+    int? page = null,
+    int? size = null,
+    string status = null,
+    DateTime? createdSince = null,
+    DateTime? createdUntil = null)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `recipientId` | `string` | Template, Required | Recipient id |
+| `page` | `int?` | Query, Optional | Page number |
+| `size` | `int?` | Query, Optional | Page size |
+| `status` | `string` | Query, Optional | Filter for transfer status |
+| `createdSince` | `DateTime?` | Query, Optional | Filter for start range of transfer creation date |
+| `createdUntil` | `DateTime?` | Query, Optional | Filter for end range of transfer creation date |
+
+## Response Type
+
+[`Task<Models.ListTransferResponse>`](/doc/models/list-transfer-response.md)
+
+## Example Usage
+
+```csharp
+string recipientId = "recipient_id0";
+
+try
+{
+    ListTransferResponse result = await recipientsController.GetTransfersAsync(recipientId, null, null, null, null, null);
 }
 catch (ApiException e){};
 ```

--- a/doc/controllers/subscriptions.md
+++ b/doc/controllers/subscriptions.md
@@ -11,39 +11,39 @@ ISubscriptionsController subscriptionsController = client.SubscriptionsControlle
 ## Methods
 
 * [Renew Subscription](/doc/controllers/subscriptions.md#renew-subscription)
-* [Update Subscription Card](/doc/controllers/subscriptions.md#update-subscription-card)
-* [Delete Usage](/doc/controllers/subscriptions.md#delete-usage)
-* [Create Discount](/doc/controllers/subscriptions.md#create-discount)
-* [Create an Usage](/doc/controllers/subscriptions.md#create-an-usage)
-* [Update Current Cycle Status](/doc/controllers/subscriptions.md#update-current-cycle-status)
 * [Delete Discount](/doc/controllers/subscriptions.md#delete-discount)
-* [Get Subscription Items](/doc/controllers/subscriptions.md#get-subscription-items)
-* [Update Subscription Payment Method](/doc/controllers/subscriptions.md#update-subscription-payment-method)
-* [Get Subscription Item](/doc/controllers/subscriptions.md#get-subscription-item)
 * [Get Subscriptions](/doc/controllers/subscriptions.md#get-subscriptions)
-* [Cancel Subscription](/doc/controllers/subscriptions.md#cancel-subscription)
-* [Create Increment](/doc/controllers/subscriptions.md#create-increment)
-* [Create Usage](/doc/controllers/subscriptions.md#create-usage)
 * [Get Discount by Id](/doc/controllers/subscriptions.md#get-discount-by-id)
 * [Create Subscription](/doc/controllers/subscriptions.md#create-subscription)
 * [Get Increment by Id](/doc/controllers/subscriptions.md#get-increment-by-id)
-* [Update Subscription Affiliation Id](/doc/controllers/subscriptions.md#update-subscription-affiliation-id)
 * [Update Subscription Metadata](/doc/controllers/subscriptions.md#update-subscription-metadata)
 * [Delete Increment](/doc/controllers/subscriptions.md#delete-increment)
-* [Get Subscription Cycles](/doc/controllers/subscriptions.md#get-subscription-cycles)
+* [Get Subscription](/doc/controllers/subscriptions.md#get-subscription)
+* [Update Latest Period End At](/doc/controllers/subscriptions.md#update-latest-period-end-at)
+* [Update Current Cycle Status](/doc/controllers/subscriptions.md#update-current-cycle-status)
+* [Get Subscription Items](/doc/controllers/subscriptions.md#get-subscription-items)
+* [Get Subscription Item](/doc/controllers/subscriptions.md#get-subscription-item)
+* [Update Subscription Affiliation Id](/doc/controllers/subscriptions.md#update-subscription-affiliation-id)
 * [Get Discounts](/doc/controllers/subscriptions.md#get-discounts)
-* [Update Subscription Billing Date](/doc/controllers/subscriptions.md#update-subscription-billing-date)
+* [Update Subscription Item](/doc/controllers/subscriptions.md#update-subscription-item)
+* [Create Subscription Item](/doc/controllers/subscriptions.md#create-subscription-item)
+* [Get Usages](/doc/controllers/subscriptions.md#get-usages)
+* [Update Subscription Minium Price](/doc/controllers/subscriptions.md#update-subscription-minium-price)
+* [Get Subscription Cycle by Id](/doc/controllers/subscriptions.md#get-subscription-cycle-by-id)
+* [Create an Usage](/doc/controllers/subscriptions.md#create-an-usage)
+* [Cancel Subscription](/doc/controllers/subscriptions.md#cancel-subscription)
 * [Delete Subscription Item](/doc/controllers/subscriptions.md#delete-subscription-item)
 * [Get Increments](/doc/controllers/subscriptions.md#get-increments)
 * [Update Subscription Due Days](/doc/controllers/subscriptions.md#update-subscription-due-days)
+* [Update Subscription Card](/doc/controllers/subscriptions.md#update-subscription-card)
+* [Delete Usage](/doc/controllers/subscriptions.md#delete-usage)
+* [Create Discount](/doc/controllers/subscriptions.md#create-discount)
+* [Update Subscription Payment Method](/doc/controllers/subscriptions.md#update-subscription-payment-method)
+* [Create Increment](/doc/controllers/subscriptions.md#create-increment)
+* [Create Usage](/doc/controllers/subscriptions.md#create-usage)
+* [Get Subscription Cycles](/doc/controllers/subscriptions.md#get-subscription-cycles)
+* [Update Subscription Billing Date](/doc/controllers/subscriptions.md#update-subscription-billing-date)
 * [Update Subscription Start At](/doc/controllers/subscriptions.md#update-subscription-start-at)
-* [Update Subscription Item](/doc/controllers/subscriptions.md#update-subscription-item)
-* [Create Subscription Item](/doc/controllers/subscriptions.md#create-subscription-item)
-* [Get Subscription](/doc/controllers/subscriptions.md#get-subscription)
-* [Get Usages](/doc/controllers/subscriptions.md#get-usages)
-* [Update Latest Period End At](/doc/controllers/subscriptions.md#update-latest-period-end-at)
-* [Update Subscription Minium Price](/doc/controllers/subscriptions.md#update-subscription-minium-price)
-* [Get Subscription Cycle by Id](/doc/controllers/subscriptions.md#get-subscription-cycle-by-id)
 * [Get Usage Report](/doc/controllers/subscriptions.md#get-usage-report)
 
 
@@ -74,227 +74,6 @@ string subscriptionId = "subscription_id0";
 try
 {
     GetPeriodResponse result = await subscriptionsController.RenewSubscriptionAsync(subscriptionId, null);
-}
-catch (ApiException e){};
-```
-
-
-# Update Subscription Card
-
-Updates the credit card from a subscription
-
-```csharp
-UpdateSubscriptionCardAsync(
-    string subscriptionId,
-    Models.UpdateSubscriptionCardRequest request,
-    string idempotencyKey = null)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `subscriptionId` | `string` | Template, Required | Subscription id |
-| `request` | [`Models.UpdateSubscriptionCardRequest`](/doc/models/update-subscription-card-request.md) | Body, Required | Request for updating a card |
-| `idempotencyKey` | `string` | Header, Optional | - |
-
-## Response Type
-
-[`Task<Models.GetSubscriptionResponse>`](/doc/models/get-subscription-response.md)
-
-## Example Usage
-
-```csharp
-string subscriptionId = "subscription_id0";
-var request = new UpdateSubscriptionCardRequest();
-request.Card = new CreateCardRequest();
-request.Card.Number = "number2";
-request.Card.HolderName = "holder_name6";
-request.Card.ExpMonth = 80;
-request.Card.ExpYear = 216;
-request.Card.Cvv = "cvv8";
-request.Card.BillingAddress = new CreateAddressRequest();
-request.Card.BillingAddress.Street = "street2";
-request.Card.BillingAddress.Number = "number0";
-request.Card.BillingAddress.ZipCode = "zip_code6";
-request.Card.BillingAddress.Neighborhood = "neighborhood8";
-request.Card.BillingAddress.City = "city8";
-request.Card.BillingAddress.State = "state2";
-request.Card.BillingAddress.Country = "country6";
-request.Card.BillingAddress.Complement = "complement2";
-request.Card.BillingAddress.Metadata = new Dictionary<string, string>();
-request.Card.BillingAddress.Metadata.Add("key0", "metadata1");
-request.Card.BillingAddress.Line1 = "line_14";
-request.Card.BillingAddress.Line2 = "line_20";
-request.Card.Brand = "brand4";
-request.Card.BillingAddressId = "billing_address_id6";
-request.Card.Metadata = new Dictionary<string, string>();
-request.Card.Metadata.Add("key0", "metadata3");
-request.Card.Metadata.Add("key1", "metadata4");
-request.Card.Metadata.Add("key2", "metadata5");
-request.Card.Type = "credit";
-request.Card.Options = new CreateCardOptionsRequest();
-request.Card.Options.VerifyCard = false;
-request.Card.PrivateLabel = false;
-request.Card.Label = "label0";
-request.CardId = "card_id2";
-
-try
-{
-    GetSubscriptionResponse result = await subscriptionsController.UpdateSubscriptionCardAsync(subscriptionId, request, null);
-}
-catch (ApiException e){};
-```
-
-
-# Delete Usage
-
-Deletes a usage
-
-```csharp
-DeleteUsageAsync(
-    string subscriptionId,
-    string itemId,
-    string usageId,
-    string idempotencyKey = null)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `subscriptionId` | `string` | Template, Required | The subscription id |
-| `itemId` | `string` | Template, Required | The subscription item id |
-| `usageId` | `string` | Template, Required | The usage id |
-| `idempotencyKey` | `string` | Header, Optional | - |
-
-## Response Type
-
-[`Task<Models.GetUsageResponse>`](/doc/models/get-usage-response.md)
-
-## Example Usage
-
-```csharp
-string subscriptionId = "subscription_id0";
-string itemId = "item_id0";
-string usageId = "usage_id0";
-
-try
-{
-    GetUsageResponse result = await subscriptionsController.DeleteUsageAsync(subscriptionId, itemId, usageId, null);
-}
-catch (ApiException e){};
-```
-
-
-# Create Discount
-
-Creates a discount
-
-```csharp
-CreateDiscountAsync(
-    string subscriptionId,
-    Models.CreateDiscountRequest request,
-    string idempotencyKey = null)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `subscriptionId` | `string` | Template, Required | Subscription id |
-| `request` | [`Models.CreateDiscountRequest`](/doc/models/create-discount-request.md) | Body, Required | Request for creating a discount |
-| `idempotencyKey` | `string` | Header, Optional | - |
-
-## Response Type
-
-[`Task<Models.GetDiscountResponse>`](/doc/models/get-discount-response.md)
-
-## Example Usage
-
-```csharp
-string subscriptionId = "subscription_id0";
-var request = new CreateDiscountRequest();
-request.MValue = 185.28;
-request.DiscountType = "discount_type4";
-request.ItemId = "item_id6";
-
-try
-{
-    GetDiscountResponse result = await subscriptionsController.CreateDiscountAsync(subscriptionId, request, null);
-}
-catch (ApiException e){};
-```
-
-
-# Create an Usage
-
-Create Usage
-
-```csharp
-CreateAnUsageAsync(
-    string subscriptionId,
-    string itemId,
-    string idempotencyKey = null)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `subscriptionId` | `string` | Template, Required | Subscription id |
-| `itemId` | `string` | Template, Required | Item id |
-| `idempotencyKey` | `string` | Header, Optional | - |
-
-## Response Type
-
-[`Task<Models.GetUsageResponse>`](/doc/models/get-usage-response.md)
-
-## Example Usage
-
-```csharp
-string subscriptionId = "subscription_id0";
-string itemId = "item_id0";
-
-try
-{
-    GetUsageResponse result = await subscriptionsController.CreateAnUsageAsync(subscriptionId, itemId, null);
-}
-catch (ApiException e){};
-```
-
-
-# Update Current Cycle Status
-
-```csharp
-UpdateCurrentCycleStatusAsync(
-    string subscriptionId,
-    Models.UpdateCurrentCycleStatusRequest request,
-    string idempotencyKey = null)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `subscriptionId` | `string` | Template, Required | Subscription Id |
-| `request` | [`Models.UpdateCurrentCycleStatusRequest`](/doc/models/update-current-cycle-status-request.md) | Body, Required | Request for updating the end date of the subscription current status |
-| `idempotencyKey` | `string` | Header, Optional | - |
-
-## Response Type
-
-`Task`
-
-## Example Usage
-
-```csharp
-string subscriptionId = "subscription_id0";
-var request = new UpdateCurrentCycleStatusRequest();
-request.Status = "status8";
-
-try
-{
-    await subscriptionsController.UpdateCurrentCycleStatusAsync(subscriptionId, request, null);
 }
 catch (ApiException e){};
 ```
@@ -332,158 +111,6 @@ string discountId = "discount_id8";
 try
 {
     GetDiscountResponse result = await subscriptionsController.DeleteDiscountAsync(subscriptionId, discountId, null);
-}
-catch (ApiException e){};
-```
-
-
-# Get Subscription Items
-
-Get Subscription Items
-
-```csharp
-GetSubscriptionItemsAsync(
-    string subscriptionId,
-    int? page = null,
-    int? size = null,
-    string name = null,
-    string code = null,
-    string status = null,
-    string description = null,
-    string createdSince = null,
-    string createdUntil = null)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `subscriptionId` | `string` | Template, Required | The subscription id |
-| `page` | `int?` | Query, Optional | Page number |
-| `size` | `int?` | Query, Optional | Page size |
-| `name` | `string` | Query, Optional | The item name |
-| `code` | `string` | Query, Optional | Identification code in the client system |
-| `status` | `string` | Query, Optional | The item statis |
-| `description` | `string` | Query, Optional | The item description |
-| `createdSince` | `string` | Query, Optional | Filter for item's creation date start range |
-| `createdUntil` | `string` | Query, Optional | Filter for item's creation date end range |
-
-## Response Type
-
-[`Task<Models.ListSubscriptionItemsResponse>`](/doc/models/list-subscription-items-response.md)
-
-## Example Usage
-
-```csharp
-string subscriptionId = "subscription_id0";
-
-try
-{
-    ListSubscriptionItemsResponse result = await subscriptionsController.GetSubscriptionItemsAsync(subscriptionId, null, null, null, null, null, null, null, null);
-}
-catch (ApiException e){};
-```
-
-
-# Update Subscription Payment Method
-
-Updates the payment method from a subscription
-
-```csharp
-UpdateSubscriptionPaymentMethodAsync(
-    string subscriptionId,
-    Models.UpdateSubscriptionPaymentMethodRequest request,
-    string idempotencyKey = null)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `subscriptionId` | `string` | Template, Required | Subscription id |
-| `request` | [`Models.UpdateSubscriptionPaymentMethodRequest`](/doc/models/update-subscription-payment-method-request.md) | Body, Required | Request for updating the paymentmethod from a subscription |
-| `idempotencyKey` | `string` | Header, Optional | - |
-
-## Response Type
-
-[`Task<Models.GetSubscriptionResponse>`](/doc/models/get-subscription-response.md)
-
-## Example Usage
-
-```csharp
-string subscriptionId = "subscription_id0";
-var request = new UpdateSubscriptionPaymentMethodRequest();
-request.PaymentMethod = "payment_method4";
-request.CardId = "card_id2";
-request.Card = new CreateCardRequest();
-request.Card.Number = "number2";
-request.Card.HolderName = "holder_name6";
-request.Card.ExpMonth = 80;
-request.Card.ExpYear = 216;
-request.Card.Cvv = "cvv8";
-request.Card.BillingAddress = new CreateAddressRequest();
-request.Card.BillingAddress.Street = "street2";
-request.Card.BillingAddress.Number = "number0";
-request.Card.BillingAddress.ZipCode = "zip_code6";
-request.Card.BillingAddress.Neighborhood = "neighborhood8";
-request.Card.BillingAddress.City = "city8";
-request.Card.BillingAddress.State = "state2";
-request.Card.BillingAddress.Country = "country6";
-request.Card.BillingAddress.Complement = "complement2";
-request.Card.BillingAddress.Metadata = new Dictionary<string, string>();
-request.Card.BillingAddress.Metadata.Add("key0", "metadata1");
-request.Card.BillingAddress.Line1 = "line_14";
-request.Card.BillingAddress.Line2 = "line_20";
-request.Card.Brand = "brand4";
-request.Card.BillingAddressId = "billing_address_id6";
-request.Card.Metadata = new Dictionary<string, string>();
-request.Card.Metadata.Add("key0", "metadata3");
-request.Card.Metadata.Add("key1", "metadata4");
-request.Card.Metadata.Add("key2", "metadata5");
-request.Card.Type = "credit";
-request.Card.Options = new CreateCardOptionsRequest();
-request.Card.Options.VerifyCard = false;
-request.Card.PrivateLabel = false;
-request.Card.Label = "label0";
-
-try
-{
-    GetSubscriptionResponse result = await subscriptionsController.UpdateSubscriptionPaymentMethodAsync(subscriptionId, request, null);
-}
-catch (ApiException e){};
-```
-
-
-# Get Subscription Item
-
-Get Subscription Item
-
-```csharp
-GetSubscriptionItemAsync(
-    string subscriptionId,
-    string itemId)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `subscriptionId` | `string` | Template, Required | Subscription Id |
-| `itemId` | `string` | Template, Required | Item id |
-
-## Response Type
-
-[`Task<Models.GetSubscriptionItemResponse>`](/doc/models/get-subscription-item-response.md)
-
-## Example Usage
-
-```csharp
-string subscriptionId = "subscription_id0";
-string itemId = "item_id0";
-
-try
-{
-    GetSubscriptionItemResponse result = await subscriptionsController.GetSubscriptionItemAsync(subscriptionId, itemId);
 }
 catch (ApiException e){};
 ```
@@ -536,127 +163,6 @@ GetSubscriptionsAsync(
 try
 {
     ListSubscriptionsResponse result = await subscriptionsController.GetSubscriptionsAsync(null, null, null, null, null, null, null, null, null, null, null, null);
-}
-catch (ApiException e){};
-```
-
-
-# Cancel Subscription
-
-Cancels a subscription
-
-```csharp
-CancelSubscriptionAsync(
-    string subscriptionId,
-    Models.CreateCancelSubscriptionRequest request = null,
-    string idempotencyKey = null)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `subscriptionId` | `string` | Template, Required | Subscription id |
-| `request` | [`Models.CreateCancelSubscriptionRequest`](/doc/models/create-cancel-subscription-request.md) | Body, Optional | Request for cancelling a subscription |
-| `idempotencyKey` | `string` | Header, Optional | - |
-
-## Response Type
-
-[`Task<Models.GetSubscriptionResponse>`](/doc/models/get-subscription-response.md)
-
-## Example Usage
-
-```csharp
-string subscriptionId = "subscription_id0";
-var request = new CreateCancelSubscriptionRequest();
-request.CancelPendingInvoices = true;
-
-try
-{
-    GetSubscriptionResponse result = await subscriptionsController.CancelSubscriptionAsync(subscriptionId, request, null);
-}
-catch (ApiException e){};
-```
-
-
-# Create Increment
-
-Creates a increment
-
-```csharp
-CreateIncrementAsync(
-    string subscriptionId,
-    Models.CreateIncrementRequest request,
-    string idempotencyKey = null)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `subscriptionId` | `string` | Template, Required | Subscription id |
-| `request` | [`Models.CreateIncrementRequest`](/doc/models/create-increment-request.md) | Body, Required | Request for creating a increment |
-| `idempotencyKey` | `string` | Header, Optional | - |
-
-## Response Type
-
-[`Task<Models.GetIncrementResponse>`](/doc/models/get-increment-response.md)
-
-## Example Usage
-
-```csharp
-string subscriptionId = "subscription_id0";
-var request = new CreateIncrementRequest();
-request.MValue = 185.28;
-request.IncrementType = "increment_type8";
-request.ItemId = "item_id6";
-
-try
-{
-    GetIncrementResponse result = await subscriptionsController.CreateIncrementAsync(subscriptionId, request, null);
-}
-catch (ApiException e){};
-```
-
-
-# Create Usage
-
-Creates a usage
-
-```csharp
-CreateUsageAsync(
-    string subscriptionId,
-    string itemId,
-    Models.CreateUsageRequest body,
-    string idempotencyKey = null)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `subscriptionId` | `string` | Template, Required | Subscription Id |
-| `itemId` | `string` | Template, Required | Item id |
-| `body` | [`Models.CreateUsageRequest`](/doc/models/create-usage-request.md) | Body, Required | Request for creating a usage |
-| `idempotencyKey` | `string` | Header, Optional | - |
-
-## Response Type
-
-[`Task<Models.GetUsageResponse>`](/doc/models/get-usage-response.md)
-
-## Example Usage
-
-```csharp
-string subscriptionId = "subscription_id0";
-string itemId = "item_id0";
-var body = new CreateUsageRequest();
-body.Quantity = 156;
-body.Description = "description4";
-body.UsedAt = DateTime.Parse("2016-03-13T12:52:32.123Z");
-
-try
-{
-    GetUsageResponse result = await subscriptionsController.CreateUsageAsync(subscriptionId, itemId, body, null);
 }
 catch (ApiException e){};
 ```
@@ -1004,42 +510,6 @@ catch (ApiException e){};
 ```
 
 
-# Update Subscription Affiliation Id
-
-```csharp
-UpdateSubscriptionAffiliationIdAsync(
-    string subscriptionId,
-    Models.UpdateSubscriptionAffiliationIdRequest request,
-    string idempotencyKey = null)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `subscriptionId` | `string` | Template, Required | - |
-| `request` | [`Models.UpdateSubscriptionAffiliationIdRequest`](/doc/models/update-subscription-affiliation-id-request.md) | Body, Required | Request for updating a subscription affiliation id |
-| `idempotencyKey` | `string` | Header, Optional | - |
-
-## Response Type
-
-[`Task<Models.GetSubscriptionResponse>`](/doc/models/get-subscription-response.md)
-
-## Example Usage
-
-```csharp
-string subscriptionId = "subscription_id0";
-var request = new UpdateSubscriptionAffiliationIdRequest();
-request.GatewayAffiliationId = "gateway_affiliation_id2";
-
-try
-{
-    GetSubscriptionResponse result = await subscriptionsController.UpdateSubscriptionAffiliationIdAsync(subscriptionId, request, null);
-}
-catch (ApiException e){};
-```
-
-
 # Update Subscription Metadata
 
 Updates the metadata from a subscription
@@ -1116,13 +586,80 @@ catch (ApiException e){};
 ```
 
 
-# Get Subscription Cycles
+# Get Subscription
+
+Gets a subscription
 
 ```csharp
-GetSubscriptionCyclesAsync(
+GetSubscriptionAsync(
+    string subscriptionId)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `subscriptionId` | `string` | Template, Required | Subscription id |
+
+## Response Type
+
+[`Task<Models.GetSubscriptionResponse>`](/doc/models/get-subscription-response.md)
+
+## Example Usage
+
+```csharp
+string subscriptionId = "subscription_id0";
+
+try
+{
+    GetSubscriptionResponse result = await subscriptionsController.GetSubscriptionAsync(subscriptionId);
+}
+catch (ApiException e){};
+```
+
+
+# Update Latest Period End At
+
+```csharp
+UpdateLatestPeriodEndAtAsync(
     string subscriptionId,
-    string page,
-    string size)
+    Models.UpdateCurrentCycleEndDateRequest request,
+    string idempotencyKey = null)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `subscriptionId` | `string` | Template, Required | - |
+| `request` | [`Models.UpdateCurrentCycleEndDateRequest`](/doc/models/update-current-cycle-end-date-request.md) | Body, Required | Request for updating the end date of the current signature cycle |
+| `idempotencyKey` | `string` | Header, Optional | - |
+
+## Response Type
+
+[`Task<Models.GetSubscriptionResponse>`](/doc/models/get-subscription-response.md)
+
+## Example Usage
+
+```csharp
+string subscriptionId = "subscription_id0";
+var request = new UpdateCurrentCycleEndDateRequest();
+
+try
+{
+    GetSubscriptionResponse result = await subscriptionsController.UpdateLatestPeriodEndAtAsync(subscriptionId, request, null);
+}
+catch (ApiException e){};
+```
+
+
+# Update Current Cycle Status
+
+```csharp
+UpdateCurrentCycleStatusAsync(
+    string subscriptionId,
+    Models.UpdateCurrentCycleStatusRequest request,
+    string idempotencyKey = null)
 ```
 
 ## Parameters
@@ -1130,23 +667,142 @@ GetSubscriptionCyclesAsync(
 | Parameter | Type | Tags | Description |
 |  --- | --- | --- | --- |
 | `subscriptionId` | `string` | Template, Required | Subscription Id |
-| `page` | `string` | Query, Required | Page number |
-| `size` | `string` | Query, Required | Page size |
+| `request` | [`Models.UpdateCurrentCycleStatusRequest`](/doc/models/update-current-cycle-status-request.md) | Body, Required | Request for updating the end date of the subscription current status |
+| `idempotencyKey` | `string` | Header, Optional | - |
 
 ## Response Type
 
-[`Task<Models.ListCyclesResponse>`](/doc/models/list-cycles-response.md)
+`Task`
 
 ## Example Usage
 
 ```csharp
 string subscriptionId = "subscription_id0";
-string page = "page8";
-string size = "size0";
+var request = new UpdateCurrentCycleStatusRequest();
+request.Status = "status8";
 
 try
 {
-    ListCyclesResponse result = await subscriptionsController.GetSubscriptionCyclesAsync(subscriptionId, page, size);
+    await subscriptionsController.UpdateCurrentCycleStatusAsync(subscriptionId, request, null);
+}
+catch (ApiException e){};
+```
+
+
+# Get Subscription Items
+
+Get Subscription Items
+
+```csharp
+GetSubscriptionItemsAsync(
+    string subscriptionId,
+    int? page = null,
+    int? size = null,
+    string name = null,
+    string code = null,
+    string status = null,
+    string description = null,
+    string createdSince = null,
+    string createdUntil = null)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `subscriptionId` | `string` | Template, Required | The subscription id |
+| `page` | `int?` | Query, Optional | Page number |
+| `size` | `int?` | Query, Optional | Page size |
+| `name` | `string` | Query, Optional | The item name |
+| `code` | `string` | Query, Optional | Identification code in the client system |
+| `status` | `string` | Query, Optional | The item statis |
+| `description` | `string` | Query, Optional | The item description |
+| `createdSince` | `string` | Query, Optional | Filter for item's creation date start range |
+| `createdUntil` | `string` | Query, Optional | Filter for item's creation date end range |
+
+## Response Type
+
+[`Task<Models.ListSubscriptionItemsResponse>`](/doc/models/list-subscription-items-response.md)
+
+## Example Usage
+
+```csharp
+string subscriptionId = "subscription_id0";
+
+try
+{
+    ListSubscriptionItemsResponse result = await subscriptionsController.GetSubscriptionItemsAsync(subscriptionId, null, null, null, null, null, null, null, null);
+}
+catch (ApiException e){};
+```
+
+
+# Get Subscription Item
+
+Get Subscription Item
+
+```csharp
+GetSubscriptionItemAsync(
+    string subscriptionId,
+    string itemId)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `subscriptionId` | `string` | Template, Required | Subscription Id |
+| `itemId` | `string` | Template, Required | Item id |
+
+## Response Type
+
+[`Task<Models.GetSubscriptionItemResponse>`](/doc/models/get-subscription-item-response.md)
+
+## Example Usage
+
+```csharp
+string subscriptionId = "subscription_id0";
+string itemId = "item_id0";
+
+try
+{
+    GetSubscriptionItemResponse result = await subscriptionsController.GetSubscriptionItemAsync(subscriptionId, itemId);
+}
+catch (ApiException e){};
+```
+
+
+# Update Subscription Affiliation Id
+
+```csharp
+UpdateSubscriptionAffiliationIdAsync(
+    string subscriptionId,
+    Models.UpdateSubscriptionAffiliationIdRequest request,
+    string idempotencyKey = null)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `subscriptionId` | `string` | Template, Required | - |
+| `request` | [`Models.UpdateSubscriptionAffiliationIdRequest`](/doc/models/update-subscription-affiliation-id-request.md) | Body, Required | Request for updating a subscription affiliation id |
+| `idempotencyKey` | `string` | Header, Optional | - |
+
+## Response Type
+
+[`Task<Models.GetSubscriptionResponse>`](/doc/models/get-subscription-response.md)
+
+## Example Usage
+
+```csharp
+string subscriptionId = "subscription_id0";
+var request = new UpdateSubscriptionAffiliationIdRequest();
+request.GatewayAffiliationId = "gateway_affiliation_id2";
+
+try
+{
+    GetSubscriptionResponse result = await subscriptionsController.UpdateSubscriptionAffiliationIdAsync(subscriptionId, request, null);
 }
 catch (ApiException e){};
 ```
@@ -1183,191 +839,6 @@ int size = 18;
 try
 {
     ListDiscountsResponse result = await subscriptionsController.GetDiscountsAsync(subscriptionId, page, size);
-}
-catch (ApiException e){};
-```
-
-
-# Update Subscription Billing Date
-
-Updates the billing date from a subscription
-
-```csharp
-UpdateSubscriptionBillingDateAsync(
-    string subscriptionId,
-    Models.UpdateSubscriptionBillingDateRequest request,
-    string idempotencyKey = null)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `subscriptionId` | `string` | Template, Required | The subscription id |
-| `request` | [`Models.UpdateSubscriptionBillingDateRequest`](/doc/models/update-subscription-billing-date-request.md) | Body, Required | Request for updating the subscription billing date |
-| `idempotencyKey` | `string` | Header, Optional | - |
-
-## Response Type
-
-[`Task<Models.GetSubscriptionResponse>`](/doc/models/get-subscription-response.md)
-
-## Example Usage
-
-```csharp
-string subscriptionId = "subscription_id0";
-var request = new UpdateSubscriptionBillingDateRequest();
-request.NextBillingAt = DateTime.Parse("2016-03-13T12:52:32.123Z");
-
-try
-{
-    GetSubscriptionResponse result = await subscriptionsController.UpdateSubscriptionBillingDateAsync(subscriptionId, request, null);
-}
-catch (ApiException e){};
-```
-
-
-# Delete Subscription Item
-
-Deletes a subscription item
-
-```csharp
-DeleteSubscriptionItemAsync(
-    string subscriptionId,
-    string subscriptionItemId,
-    string idempotencyKey = null)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `subscriptionId` | `string` | Template, Required | Subscription id |
-| `subscriptionItemId` | `string` | Template, Required | Subscription item id |
-| `idempotencyKey` | `string` | Header, Optional | - |
-
-## Response Type
-
-[`Task<Models.GetSubscriptionItemResponse>`](/doc/models/get-subscription-item-response.md)
-
-## Example Usage
-
-```csharp
-string subscriptionId = "subscription_id0";
-string subscriptionItemId = "subscription_item_id4";
-
-try
-{
-    GetSubscriptionItemResponse result = await subscriptionsController.DeleteSubscriptionItemAsync(subscriptionId, subscriptionItemId, null);
-}
-catch (ApiException e){};
-```
-
-
-# Get Increments
-
-```csharp
-GetIncrementsAsync(
-    string subscriptionId,
-    int? page = null,
-    int? size = null)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `subscriptionId` | `string` | Template, Required | The subscription id |
-| `page` | `int?` | Query, Optional | Page number |
-| `size` | `int?` | Query, Optional | Page size |
-
-## Response Type
-
-[`Task<Models.ListIncrementsResponse>`](/doc/models/list-increments-response.md)
-
-## Example Usage
-
-```csharp
-string subscriptionId = "subscription_id0";
-
-try
-{
-    ListIncrementsResponse result = await subscriptionsController.GetIncrementsAsync(subscriptionId, null, null);
-}
-catch (ApiException e){};
-```
-
-
-# Update Subscription Due Days
-
-Updates the boleto due days from a subscription
-
-```csharp
-UpdateSubscriptionDueDaysAsync(
-    string subscriptionId,
-    Models.UpdateSubscriptionDueDaysRequest request,
-    string idempotencyKey = null)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `subscriptionId` | `string` | Template, Required | Subscription Id |
-| `request` | [`Models.UpdateSubscriptionDueDaysRequest`](/doc/models/update-subscription-due-days-request.md) | Body, Required | - |
-| `idempotencyKey` | `string` | Header, Optional | - |
-
-## Response Type
-
-[`Task<Models.GetSubscriptionResponse>`](/doc/models/get-subscription-response.md)
-
-## Example Usage
-
-```csharp
-string subscriptionId = "subscription_id0";
-var request = new UpdateSubscriptionDueDaysRequest();
-request.BoletoDueDays = 226;
-
-try
-{
-    GetSubscriptionResponse result = await subscriptionsController.UpdateSubscriptionDueDaysAsync(subscriptionId, request, null);
-}
-catch (ApiException e){};
-```
-
-
-# Update Subscription Start At
-
-Updates the start at date from a subscription
-
-```csharp
-UpdateSubscriptionStartAtAsync(
-    string subscriptionId,
-    Models.UpdateSubscriptionStartAtRequest request,
-    string idempotencyKey = null)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `subscriptionId` | `string` | Template, Required | The subscription id |
-| `request` | [`Models.UpdateSubscriptionStartAtRequest`](/doc/models/update-subscription-start-at-request.md) | Body, Required | Request for updating the subscription start date |
-| `idempotencyKey` | `string` | Header, Optional | - |
-
-## Response Type
-
-[`Task<Models.GetSubscriptionResponse>`](/doc/models/get-subscription-response.md)
-
-## Example Usage
-
-```csharp
-string subscriptionId = "subscription_id0";
-var request = new UpdateSubscriptionStartAtRequest();
-request.StartAt = DateTime.Parse("2016-03-13T12:52:32.123Z");
-
-try
-{
-    GetSubscriptionResponse result = await subscriptionsController.UpdateSubscriptionStartAtAsync(subscriptionId, request, null);
 }
 catch (ApiException e){};
 ```
@@ -1494,38 +965,6 @@ catch (ApiException e){};
 ```
 
 
-# Get Subscription
-
-Gets a subscription
-
-```csharp
-GetSubscriptionAsync(
-    string subscriptionId)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `subscriptionId` | `string` | Template, Required | Subscription id |
-
-## Response Type
-
-[`Task<Models.GetSubscriptionResponse>`](/doc/models/get-subscription-response.md)
-
-## Example Usage
-
-```csharp
-string subscriptionId = "subscription_id0";
-
-try
-{
-    GetSubscriptionResponse result = await subscriptionsController.GetSubscriptionAsync(subscriptionId);
-}
-catch (ApiException e){};
-```
-
-
 # Get Usages
 
 Lists all usages from a subscription item
@@ -1568,41 +1007,6 @@ string itemId = "item_id0";
 try
 {
     ListUsagesResponse result = await subscriptionsController.GetUsagesAsync(subscriptionId, itemId, null, null, null, null, null, null);
-}
-catch (ApiException e){};
-```
-
-
-# Update Latest Period End At
-
-```csharp
-UpdateLatestPeriodEndAtAsync(
-    string subscriptionId,
-    Models.UpdateCurrentCycleEndDateRequest request,
-    string idempotencyKey = null)
-```
-
-## Parameters
-
-| Parameter | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `subscriptionId` | `string` | Template, Required | - |
-| `request` | [`Models.UpdateCurrentCycleEndDateRequest`](/doc/models/update-current-cycle-end-date-request.md) | Body, Required | Request for updating the end date of the current signature cycle |
-| `idempotencyKey` | `string` | Header, Optional | - |
-
-## Response Type
-
-[`Task<Models.GetSubscriptionResponse>`](/doc/models/get-subscription-response.md)
-
-## Example Usage
-
-```csharp
-string subscriptionId = "subscription_id0";
-var request = new UpdateCurrentCycleEndDateRequest();
-
-try
-{
-    GetSubscriptionResponse result = await subscriptionsController.UpdateLatestPeriodEndAtAsync(subscriptionId, request, null);
 }
 catch (ApiException e){};
 ```
@@ -1673,6 +1077,602 @@ string cycleId = "cycleId0";
 try
 {
     GetPeriodResponse result = await subscriptionsController.GetSubscriptionCycleByIdAsync(subscriptionId, cycleId);
+}
+catch (ApiException e){};
+```
+
+
+# Create an Usage
+
+Create Usage
+
+```csharp
+CreateAnUsageAsync(
+    string subscriptionId,
+    string itemId,
+    string idempotencyKey = null)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `subscriptionId` | `string` | Template, Required | Subscription id |
+| `itemId` | `string` | Template, Required | Item id |
+| `idempotencyKey` | `string` | Header, Optional | - |
+
+## Response Type
+
+[`Task<Models.GetUsageResponse>`](/doc/models/get-usage-response.md)
+
+## Example Usage
+
+```csharp
+string subscriptionId = "subscription_id0";
+string itemId = "item_id0";
+
+try
+{
+    GetUsageResponse result = await subscriptionsController.CreateAnUsageAsync(subscriptionId, itemId, null);
+}
+catch (ApiException e){};
+```
+
+
+# Cancel Subscription
+
+Cancels a subscription
+
+```csharp
+CancelSubscriptionAsync(
+    string subscriptionId,
+    Models.CreateCancelSubscriptionRequest request = null,
+    string idempotencyKey = null)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `subscriptionId` | `string` | Template, Required | Subscription id |
+| `request` | [`Models.CreateCancelSubscriptionRequest`](/doc/models/create-cancel-subscription-request.md) | Body, Optional | Request for cancelling a subscription |
+| `idempotencyKey` | `string` | Header, Optional | - |
+
+## Response Type
+
+[`Task<Models.GetSubscriptionResponse>`](/doc/models/get-subscription-response.md)
+
+## Example Usage
+
+```csharp
+string subscriptionId = "subscription_id0";
+var request = new CreateCancelSubscriptionRequest();
+request.CancelPendingInvoices = true;
+
+try
+{
+    GetSubscriptionResponse result = await subscriptionsController.CancelSubscriptionAsync(subscriptionId, request, null);
+}
+catch (ApiException e){};
+```
+
+
+# Delete Subscription Item
+
+Deletes a subscription item
+
+```csharp
+DeleteSubscriptionItemAsync(
+    string subscriptionId,
+    string subscriptionItemId,
+    string idempotencyKey = null)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `subscriptionId` | `string` | Template, Required | Subscription id |
+| `subscriptionItemId` | `string` | Template, Required | Subscription item id |
+| `idempotencyKey` | `string` | Header, Optional | - |
+
+## Response Type
+
+[`Task<Models.GetSubscriptionItemResponse>`](/doc/models/get-subscription-item-response.md)
+
+## Example Usage
+
+```csharp
+string subscriptionId = "subscription_id0";
+string subscriptionItemId = "subscription_item_id4";
+
+try
+{
+    GetSubscriptionItemResponse result = await subscriptionsController.DeleteSubscriptionItemAsync(subscriptionId, subscriptionItemId, null);
+}
+catch (ApiException e){};
+```
+
+
+# Get Increments
+
+```csharp
+GetIncrementsAsync(
+    string subscriptionId,
+    int? page = null,
+    int? size = null)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `subscriptionId` | `string` | Template, Required | The subscription id |
+| `page` | `int?` | Query, Optional | Page number |
+| `size` | `int?` | Query, Optional | Page size |
+
+## Response Type
+
+[`Task<Models.ListIncrementsResponse>`](/doc/models/list-increments-response.md)
+
+## Example Usage
+
+```csharp
+string subscriptionId = "subscription_id0";
+
+try
+{
+    ListIncrementsResponse result = await subscriptionsController.GetIncrementsAsync(subscriptionId, null, null);
+}
+catch (ApiException e){};
+```
+
+
+# Update Subscription Due Days
+
+Updates the boleto due days from a subscription
+
+```csharp
+UpdateSubscriptionDueDaysAsync(
+    string subscriptionId,
+    Models.UpdateSubscriptionDueDaysRequest request,
+    string idempotencyKey = null)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `subscriptionId` | `string` | Template, Required | Subscription Id |
+| `request` | [`Models.UpdateSubscriptionDueDaysRequest`](/doc/models/update-subscription-due-days-request.md) | Body, Required | - |
+| `idempotencyKey` | `string` | Header, Optional | - |
+
+## Response Type
+
+[`Task<Models.GetSubscriptionResponse>`](/doc/models/get-subscription-response.md)
+
+## Example Usage
+
+```csharp
+string subscriptionId = "subscription_id0";
+var request = new UpdateSubscriptionDueDaysRequest();
+request.BoletoDueDays = 226;
+
+try
+{
+    GetSubscriptionResponse result = await subscriptionsController.UpdateSubscriptionDueDaysAsync(subscriptionId, request, null);
+}
+catch (ApiException e){};
+```
+
+
+# Update Subscription Card
+
+Updates the credit card from a subscription
+
+```csharp
+UpdateSubscriptionCardAsync(
+    string subscriptionId,
+    Models.UpdateSubscriptionCardRequest request,
+    string idempotencyKey = null)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `subscriptionId` | `string` | Template, Required | Subscription id |
+| `request` | [`Models.UpdateSubscriptionCardRequest`](/doc/models/update-subscription-card-request.md) | Body, Required | Request for updating a card |
+| `idempotencyKey` | `string` | Header, Optional | - |
+
+## Response Type
+
+[`Task<Models.GetSubscriptionResponse>`](/doc/models/get-subscription-response.md)
+
+## Example Usage
+
+```csharp
+string subscriptionId = "subscription_id0";
+var request = new UpdateSubscriptionCardRequest();
+request.Card = new CreateCardRequest();
+request.Card.Number = "number2";
+request.Card.HolderName = "holder_name6";
+request.Card.ExpMonth = 80;
+request.Card.ExpYear = 216;
+request.Card.Cvv = "cvv8";
+request.Card.BillingAddress = new CreateAddressRequest();
+request.Card.BillingAddress.Street = "street2";
+request.Card.BillingAddress.Number = "number0";
+request.Card.BillingAddress.ZipCode = "zip_code6";
+request.Card.BillingAddress.Neighborhood = "neighborhood8";
+request.Card.BillingAddress.City = "city8";
+request.Card.BillingAddress.State = "state2";
+request.Card.BillingAddress.Country = "country6";
+request.Card.BillingAddress.Complement = "complement2";
+request.Card.BillingAddress.Metadata = new Dictionary<string, string>();
+request.Card.BillingAddress.Metadata.Add("key0", "metadata1");
+request.Card.BillingAddress.Line1 = "line_14";
+request.Card.BillingAddress.Line2 = "line_20";
+request.Card.Brand = "brand4";
+request.Card.BillingAddressId = "billing_address_id6";
+request.Card.Metadata = new Dictionary<string, string>();
+request.Card.Metadata.Add("key0", "metadata3");
+request.Card.Metadata.Add("key1", "metadata4");
+request.Card.Metadata.Add("key2", "metadata5");
+request.Card.Type = "credit";
+request.Card.Options = new CreateCardOptionsRequest();
+request.Card.Options.VerifyCard = false;
+request.Card.PrivateLabel = false;
+request.Card.Label = "label0";
+request.CardId = "card_id2";
+
+try
+{
+    GetSubscriptionResponse result = await subscriptionsController.UpdateSubscriptionCardAsync(subscriptionId, request, null);
+}
+catch (ApiException e){};
+```
+
+
+# Delete Usage
+
+Deletes a usage
+
+```csharp
+DeleteUsageAsync(
+    string subscriptionId,
+    string itemId,
+    string usageId,
+    string idempotencyKey = null)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `subscriptionId` | `string` | Template, Required | The subscription id |
+| `itemId` | `string` | Template, Required | The subscription item id |
+| `usageId` | `string` | Template, Required | The usage id |
+| `idempotencyKey` | `string` | Header, Optional | - |
+
+## Response Type
+
+[`Task<Models.GetUsageResponse>`](/doc/models/get-usage-response.md)
+
+## Example Usage
+
+```csharp
+string subscriptionId = "subscription_id0";
+string itemId = "item_id0";
+string usageId = "usage_id0";
+
+try
+{
+    GetUsageResponse result = await subscriptionsController.DeleteUsageAsync(subscriptionId, itemId, usageId, null);
+}
+catch (ApiException e){};
+```
+
+
+# Create Discount
+
+Creates a discount
+
+```csharp
+CreateDiscountAsync(
+    string subscriptionId,
+    Models.CreateDiscountRequest request,
+    string idempotencyKey = null)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `subscriptionId` | `string` | Template, Required | Subscription id |
+| `request` | [`Models.CreateDiscountRequest`](/doc/models/create-discount-request.md) | Body, Required | Request for creating a discount |
+| `idempotencyKey` | `string` | Header, Optional | - |
+
+## Response Type
+
+[`Task<Models.GetDiscountResponse>`](/doc/models/get-discount-response.md)
+
+## Example Usage
+
+```csharp
+string subscriptionId = "subscription_id0";
+var request = new CreateDiscountRequest();
+request.MValue = 185.28;
+request.DiscountType = "discount_type4";
+request.ItemId = "item_id6";
+
+try
+{
+    GetDiscountResponse result = await subscriptionsController.CreateDiscountAsync(subscriptionId, request, null);
+}
+catch (ApiException e){};
+```
+
+
+# Update Subscription Payment Method
+
+Updates the payment method from a subscription
+
+```csharp
+UpdateSubscriptionPaymentMethodAsync(
+    string subscriptionId,
+    Models.UpdateSubscriptionPaymentMethodRequest request,
+    string idempotencyKey = null)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `subscriptionId` | `string` | Template, Required | Subscription id |
+| `request` | [`Models.UpdateSubscriptionPaymentMethodRequest`](/doc/models/update-subscription-payment-method-request.md) | Body, Required | Request for updating the paymentmethod from a subscription |
+| `idempotencyKey` | `string` | Header, Optional | - |
+
+## Response Type
+
+[`Task<Models.GetSubscriptionResponse>`](/doc/models/get-subscription-response.md)
+
+## Example Usage
+
+```csharp
+string subscriptionId = "subscription_id0";
+var request = new UpdateSubscriptionPaymentMethodRequest();
+request.PaymentMethod = "payment_method4";
+request.CardId = "card_id2";
+request.Card = new CreateCardRequest();
+request.Card.Number = "number2";
+request.Card.HolderName = "holder_name6";
+request.Card.ExpMonth = 80;
+request.Card.ExpYear = 216;
+request.Card.Cvv = "cvv8";
+request.Card.BillingAddress = new CreateAddressRequest();
+request.Card.BillingAddress.Street = "street2";
+request.Card.BillingAddress.Number = "number0";
+request.Card.BillingAddress.ZipCode = "zip_code6";
+request.Card.BillingAddress.Neighborhood = "neighborhood8";
+request.Card.BillingAddress.City = "city8";
+request.Card.BillingAddress.State = "state2";
+request.Card.BillingAddress.Country = "country6";
+request.Card.BillingAddress.Complement = "complement2";
+request.Card.BillingAddress.Metadata = new Dictionary<string, string>();
+request.Card.BillingAddress.Metadata.Add("key0", "metadata1");
+request.Card.BillingAddress.Line1 = "line_14";
+request.Card.BillingAddress.Line2 = "line_20";
+request.Card.Brand = "brand4";
+request.Card.BillingAddressId = "billing_address_id6";
+request.Card.Metadata = new Dictionary<string, string>();
+request.Card.Metadata.Add("key0", "metadata3");
+request.Card.Metadata.Add("key1", "metadata4");
+request.Card.Metadata.Add("key2", "metadata5");
+request.Card.Type = "credit";
+request.Card.Options = new CreateCardOptionsRequest();
+request.Card.Options.VerifyCard = false;
+request.Card.PrivateLabel = false;
+request.Card.Label = "label0";
+
+try
+{
+    GetSubscriptionResponse result = await subscriptionsController.UpdateSubscriptionPaymentMethodAsync(subscriptionId, request, null);
+}
+catch (ApiException e){};
+```
+
+
+# Create Increment
+
+Creates a increment
+
+```csharp
+CreateIncrementAsync(
+    string subscriptionId,
+    Models.CreateIncrementRequest request,
+    string idempotencyKey = null)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `subscriptionId` | `string` | Template, Required | Subscription id |
+| `request` | [`Models.CreateIncrementRequest`](/doc/models/create-increment-request.md) | Body, Required | Request for creating a increment |
+| `idempotencyKey` | `string` | Header, Optional | - |
+
+## Response Type
+
+[`Task<Models.GetIncrementResponse>`](/doc/models/get-increment-response.md)
+
+## Example Usage
+
+```csharp
+string subscriptionId = "subscription_id0";
+var request = new CreateIncrementRequest();
+request.MValue = 185.28;
+request.IncrementType = "increment_type8";
+request.ItemId = "item_id6";
+
+try
+{
+    GetIncrementResponse result = await subscriptionsController.CreateIncrementAsync(subscriptionId, request, null);
+}
+catch (ApiException e){};
+```
+
+
+# Create Usage
+
+Creates a usage
+
+```csharp
+CreateUsageAsync(
+    string subscriptionId,
+    string itemId,
+    Models.CreateUsageRequest body,
+    string idempotencyKey = null)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `subscriptionId` | `string` | Template, Required | Subscription Id |
+| `itemId` | `string` | Template, Required | Item id |
+| `body` | [`Models.CreateUsageRequest`](/doc/models/create-usage-request.md) | Body, Required | Request for creating a usage |
+| `idempotencyKey` | `string` | Header, Optional | - |
+
+## Response Type
+
+[`Task<Models.GetUsageResponse>`](/doc/models/get-usage-response.md)
+
+## Example Usage
+
+```csharp
+string subscriptionId = "subscription_id0";
+string itemId = "item_id0";
+var body = new CreateUsageRequest();
+body.Quantity = 156;
+body.Description = "description4";
+body.UsedAt = DateTime.Parse("2016-03-13T12:52:32.123Z");
+
+try
+{
+    GetUsageResponse result = await subscriptionsController.CreateUsageAsync(subscriptionId, itemId, body, null);
+}
+catch (ApiException e){};
+```
+
+
+# Get Subscription Cycles
+
+```csharp
+GetSubscriptionCyclesAsync(
+    string subscriptionId,
+    string page,
+    string size)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `subscriptionId` | `string` | Template, Required | Subscription Id |
+| `page` | `string` | Query, Required | Page number |
+| `size` | `string` | Query, Required | Page size |
+
+## Response Type
+
+[`Task<Models.ListCyclesResponse>`](/doc/models/list-cycles-response.md)
+
+## Example Usage
+
+```csharp
+string subscriptionId = "subscription_id0";
+string page = "page8";
+string size = "size0";
+
+try
+{
+    ListCyclesResponse result = await subscriptionsController.GetSubscriptionCyclesAsync(subscriptionId, page, size);
+}
+catch (ApiException e){};
+```
+
+
+# Update Subscription Billing Date
+
+Updates the billing date from a subscription
+
+```csharp
+UpdateSubscriptionBillingDateAsync(
+    string subscriptionId,
+    Models.UpdateSubscriptionBillingDateRequest request,
+    string idempotencyKey = null)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `subscriptionId` | `string` | Template, Required | The subscription id |
+| `request` | [`Models.UpdateSubscriptionBillingDateRequest`](/doc/models/update-subscription-billing-date-request.md) | Body, Required | Request for updating the subscription billing date |
+| `idempotencyKey` | `string` | Header, Optional | - |
+
+## Response Type
+
+[`Task<Models.GetSubscriptionResponse>`](/doc/models/get-subscription-response.md)
+
+## Example Usage
+
+```csharp
+string subscriptionId = "subscription_id0";
+var request = new UpdateSubscriptionBillingDateRequest();
+request.NextBillingAt = DateTime.Parse("2016-03-13T12:52:32.123Z");
+
+try
+{
+    GetSubscriptionResponse result = await subscriptionsController.UpdateSubscriptionBillingDateAsync(subscriptionId, request, null);
+}
+catch (ApiException e){};
+```
+
+
+# Update Subscription Start At
+
+Updates the start at date from a subscription
+
+```csharp
+UpdateSubscriptionStartAtAsync(
+    string subscriptionId,
+    Models.UpdateSubscriptionStartAtRequest request,
+    string idempotencyKey = null)
+```
+
+## Parameters
+
+| Parameter | Type | Tags | Description |
+|  --- | --- | --- | --- |
+| `subscriptionId` | `string` | Template, Required | The subscription id |
+| `request` | [`Models.UpdateSubscriptionStartAtRequest`](/doc/models/update-subscription-start-at-request.md) | Body, Required | Request for updating the subscription start date |
+| `idempotencyKey` | `string` | Header, Optional | - |
+
+## Response Type
+
+[`Task<Models.GetSubscriptionResponse>`](/doc/models/get-subscription-response.md)
+
+## Example Usage
+
+```csharp
+string subscriptionId = "subscription_id0";
+var request = new UpdateSubscriptionStartAtRequest();
+request.StartAt = DateTime.Parse("2016-03-13T12:52:32.123Z");
+
+try
+{
+    GetSubscriptionResponse result = await subscriptionsController.UpdateSubscriptionStartAtAsync(subscriptionId, request, null);
 }
 catch (ApiException e){};
 ```

--- a/doc/controllers/transfers.md
+++ b/doc/controllers/transfers.md
@@ -10,9 +10,32 @@ ITransfersController transfersController = client.TransfersController;
 
 ## Methods
 
+* [Get Transfers](/doc/controllers/transfers.md#get-transfers)
 * [Get Transfer by Id](/doc/controllers/transfers.md#get-transfer-by-id)
 * [Create Transfer](/doc/controllers/transfers.md#create-transfer)
-* [Get Transfers](/doc/controllers/transfers.md#get-transfers)
+
+
+# Get Transfers
+
+Gets all transfers
+
+```csharp
+GetTransfersAsync()
+```
+
+## Response Type
+
+[`Task<Models.ListTransfers>`](/doc/models/list-transfers.md)
+
+## Example Usage
+
+```csharp
+try
+{
+    ListTransfers result = await transfersController.GetTransfersAsync();
+}
+catch (ApiException e){};
+```
 
 
 # Get Transfer by Id
@@ -73,29 +96,6 @@ request.TargetId = "target_id6";
 try
 {
     GetTransfer result = await transfersController.CreateTransferAsync(request);
-}
-catch (ApiException e){};
-```
-
-
-# Get Transfers
-
-Gets all transfers
-
-```csharp
-GetTransfersAsync()
-```
-
-## Response Type
-
-[`Task<Models.ListTransfers>`](/doc/models/list-transfers.md)
-
-## Example Usage
-
-```csharp
-try
-{
-    ListTransfers result = await transfersController.GetTransfersAsync();
 }
 catch (ApiException e){};
 ```

--- a/doc/models/create-order-item-request.md
+++ b/doc/models/create-order-item-request.md
@@ -14,8 +14,6 @@ Request for creating an order item
 | `Amount` | `int` | Required | Amount |
 | `Description` | `string` | Required | Description |
 | `Quantity` | `int` | Required | Quantity |
-| `Seller` | [`Models.CreateSellerRequest`](/doc/models/create-seller-request.md) | Optional | Item seller |
-| `SellerId` | `string` | Optional | seller identificator |
 | `Category` | `string` | Required | Category |
 | `Code` | `string` | Optional | The item code passed by the client |
 
@@ -26,8 +24,6 @@ Request for creating an order item
   "amount": 46,
   "description": "description0",
   "quantity": 68,
-  "seller": null,
-  "seller_id": null,
   "category": "category2",
   "code": null
 }

--- a/doc/models/get-order-item-response.md
+++ b/doc/models/get-order-item-response.md
@@ -15,7 +15,6 @@ Response object for getting an order item
 | `Amount` | `int` | Required | - |
 | `Description` | `string` | Required | - |
 | `Quantity` | `int` | Required | - |
-| `GetSellerResponse` | [`Models.GetSellerResponse`](/doc/models/get-seller-response.md) | Optional | Seller data |
 | `Category` | `string` | Required | Category |
 | `Code` | `string` | Required | Code |
 
@@ -27,7 +26,6 @@ Response object for getting an order item
   "amount": 46,
   "description": "description0",
   "quantity": 68,
-  "GetSellerResponse": null,
   "category": "category2",
   "code": "code8"
 }

--- a/doc/models/get-order-response.md
+++ b/doc/models/get-order-response.md
@@ -43,7 +43,6 @@ Response object for getting an Order
       "amount": 13,
       "description": "description7",
       "quantity": 127,
-      "GetSellerResponse": null,
       "category": "category5",
       "code": "code5"
     },
@@ -52,7 +51,6 @@ Response object for getting an Order
       "amount": 14,
       "description": "description8",
       "quantity": 128,
-      "GetSellerResponse": null,
       "category": "category6",
       "code": "code6"
     }

--- a/doc/models/list-order-response.md
+++ b/doc/models/list-order-response.md
@@ -29,7 +29,6 @@ Response object for listing order objects
           "amount": 180,
           "description": "description2",
           "quantity": 38,
-          "GetSellerResponse": null,
           "category": "category0",
           "code": "code0"
         },
@@ -38,7 +37,6 @@ Response object for listing order objects
           "amount": 181,
           "description": "description3",
           "quantity": 39,
-          "GetSellerResponse": null,
           "category": "category1",
           "code": "code1"
         }
@@ -173,7 +171,6 @@ Response object for listing order objects
           "amount": 181,
           "description": "description3",
           "quantity": 39,
-          "GetSellerResponse": null,
           "category": "category1",
           "code": "code1"
         },
@@ -182,7 +179,6 @@ Response object for listing order objects
           "amount": 182,
           "description": "description4",
           "quantity": 40,
-          "GetSellerResponse": null,
           "category": "category2",
           "code": "code2"
         },
@@ -191,7 +187,6 @@ Response object for listing order objects
           "amount": 183,
           "description": "description5",
           "quantity": 41,
-          "GetSellerResponse": null,
           "category": "category3",
           "code": "code3"
         }


### PR DESCRIPTION
The customer should no longer use the Mark1 Sellers endpoint as it is outdated. We need to remove it from the SDK so it no longer has access.